### PR TITLE
const ref for the param in ParseTree opEquals

### DIFF
--- a/pegged/peg.d
+++ b/pegged/peg.d
@@ -87,7 +87,7 @@ struct ParseTree
     /**
     Comparing ParseTree's.
     */
-    bool opEquals(ParseTree p)
+    bool opEquals(const ParseTree p) const
     {
         return ( p.name       == name
               && p.successful == successful


### PR DESCRIPTION
Avoids a needless copy when comparing ParseTrees; also makes it possible to compare two const ParseTrees.

Unrelated: Philippe, your text editor is leaving trailing whitespace on lines. You should configure it to not do so.
