### PR TITLE
Add the missing 'ref' for the parameter

### DIFF
--- a/pegged/peg.d
+++ b/pegged/peg.d
@@ -87,7 +87,7 @@ struct ParseTree
     /**
     Comparing ParseTree's.
     */
-    bool opEquals(const ParseTree p) const
+    bool opEquals(const ref ParseTree p) const
     {
         return ( p.name       == name
               && p.successful == successful


### PR DESCRIPTION
The previous pull request should have had this; sorry for the mix-up.
