### PR TITLE
opEquals can now be called with temporaries

### DIFF
--- a/pegged/peg.d
+++ b/pegged/peg.d
@@ -86,8 +86,13 @@ struct ParseTree
         
     /**
     Comparing ParseTree's.
+
+    This function is templated so that the compiler can automatically choose a
+    const ref or plain const version for the 'p' parameter.
+    See this for more details: http://goo.gl/vfKKG
     */
-    bool opEquals(const ref ParseTree p) const
+
+    bool opEquals(T)(auto ref T p) const
     {
         return ( p.name       == name
               && p.successful == successful


### PR DESCRIPTION
The compiler will generate a version of opEquals with both const ref and with
just ref for the parameter.
