### PR TITLE
Don't install libpegged.a since it's just a static library.

### DIFF
--- a/wscript
+++ b/wscript
@@ -82,8 +82,7 @@ def configure(conf):
 def build(bld):
     bld.stlib(source = bld.path.ant_glob(os.path.join('pegged', '*.d')),
               target = 'pegged',
-              includes = [TOP],
-              install_path = '${PREFIX}/lib')
+              includes = [TOP])
 
 def dist(dst):
     '''makes a tarball for redistributing the sources'''


### PR DESCRIPTION
So I've been thinking a bit about this. Right now, the wscript supports `waf install` to install the Pegged static library. But does this really make sense?

In the majority of cases, I think people are going to rely on a specific version of Pegged in their application since its syntax and semantics are still evolving. Having a system-wide Pegged library probably doesn't make a lot of sense due to the relative API instability. I think it's a much better idea if people embed specific Pegged versions in their applications by using Git submodules or some similar mechanism.

Since Pegged has a wscript, other projects that also use Waf can trivially embed it in their application like so:

```
def build(bld):
    bld.recurse('pegged')

    bld.program(source = 'foo.d',
                use = ['pegged'],
                includes = ['pegged'],
                target = 'foo', 
                install_path = '${PREFIX}/bin')
```

This builds a binary `foo` from `foo.d` and statically links `libpegged.a` into it, thus not requiring Pegged to be installed at all. (It assumes Pegged sits in a subdirectory called `pegged`.)

Thoughts?
