### PR TITLE
Fix minor unittest build break in pegged/grammar.d

### DIFF
--- a/pegged/grammar.d
+++ b/pegged/grammar.d
@@ -1181,7 +1181,7 @@ unittest // Prefix and suffix tests
 
 
     // Comparing standard and discarded rules
-    result = PrefixSuffix.decimateTree(PrefixSuffix.Rule1("abcdef"));
+    auto result = PrefixSuffix.decimateTree(PrefixSuffix.Rule1("abcdef"));
 
     assert(result.successful);
     assert(result.begin == 0);
@@ -1452,7 +1452,7 @@ unittest // Leading alternation
         Rule3 <- (/ 'a' / 'b')
     `));
 
-    result = LeadingAlternation.decimateTree(LeadingAlternation.Rule1("a"));
+    auto result = LeadingAlternation.decimateTree(LeadingAlternation.Rule1("a"));
     assert(result.successful);
     assert(result.begin == 0);
     assert(result.end == 1);


### PR DESCRIPTION
```
chad@Hugin ~/dprojects $ git clone https://github.com/PhilippeSigaud/Pegged.git
Cloning into Pegged...
remote: Counting objects: 2206, done.
remote: Compressing objects: 100% (839/839), done.
remote: Total 2206 (delta 1430), reused 2125 (delta 1349)
Receiving objects: 100% (2206/2206), 951.91 KiB | 761 KiB/s, done.
Resolving deltas: 100% (1430/1430), done.
chad@Hugin ~/dprojects $ cd Pegged/
chad@Hugin ~/dprojects/Pegged $ dmd test.d pegged/*.d -oftest -unittest
pegged/grammar.d(1184): Error: undefined identifier result
pegged/grammar.d(1186): Error: undefined identifier result
pegged/grammar.d(1187): Error: undefined identifier result
pegged/grammar.d(1188): Error: undefined identifier result
pegged/grammar.d(1189): Error: undefined identifier result
pegged/grammar.d(1190): Error: undefined identifier result
pegged/grammar.d(1191): Error: undefined identifier result
pegged/grammar.d(1192): Error: undefined identifier result
pegged/grammar.d(1194): Error: undefined identifier result
pegged/grammar.d(1196): Error: undefined identifier result
pegged/grammar.d(1197): Error: undefined identifier result
pegged/grammar.d(1198): Error: undefined identifier result
pegged/grammar.d(1199): Error: undefined identifier result
pegged/grammar.d(1200): Error: undefined identifier result
pegged/grammar.d(1201): Error: undefined identifier result
pegged/grammar.d(1203): Error: undefined identifier result
pegged/grammar.d(1205): Error: undefined identifier result
pegged/grammar.d(1206): Error: undefined identifier result
pegged/grammar.d(1207): Error: undefined identifier result
pegged/grammar.d(1208): Error: undefined identifier result
pegged/grammar.d(1209): Error: undefined identifier result
```

It seems some types were missing in unittests.  ;)

I ran the unittests afterwards and they passed.  
