### PR TITLE
NOT asking you to merge this....

### DIFF
--- a/pegged/peg.d
+++ b/pegged/peg.d
@@ -2041,10 +2041,12 @@ template fuse(alias r)
         p = r(p);
         if(p.successful)
         {
-            string fused;
-            foreach(match; p.matches)
-                fused ~= match;
-            p.matches = (p.matches is null ? null : [fused]);
+            if (p.matches !is null)
+            {
+                p.matches[0] = std.array.join(p.matches);
+                p.matches = p.matches[0..1];
+            }
+
             p.children = null; // also discard children
         }
         return p;


### PR DESCRIPTION
just wanted to let you know about it, this seemed the easiest way.

Been playing around with a grammar for roughly tokenizing D code, want to use it for a syntax highlighter. I have been running it on the std.string module (3728 loc) to get a sense of performance, and have been optimizing the low-hanging fruit in peg.d (in this perfo branch). Here are some timings, each number is an average of 10 runs, with and without memoization (all in msecs):

git head (Memo.no): 4405, 4046, 4307
git head (Memo.yes): 5013, 4840, 4868

perfo (Memo.no): 941, 840, 929
perfo (Memo.yes): 1692, 1506, 1535

By disabling the GC before parseing, and re-enabling after, the perfo (no memo) times are further reduced (by about 300 msecs). 

The speed difference regarding memoization is interesting, I haven't looked into it any further.

Most of the optimizations are just avoiding string concats when they can be done at compile time (the ParseTree names for example are a hotspot). I also tried replacing the keywords if-chain with a CT-generated switch using a trie (ripped out of Dscanner, thanks Brian!), but that did not have as much of an impact as I thought it would. 

There are still places where performance can be improved, I just hacked at the easy stuff identified by a profiler. Let me know what you think. 

Cheers
Cal 
