### PR TITLE
Fix for compiling peg.d with keywords TRIE

### DIFF
--- a/pegged/peg.d
+++ b/pegged/peg.d
@@ -1289,6 +1289,7 @@ string printCaseStatements(V)(TrieNode!(V) node, string indentString)
 		{
             case '\n': append("\\n"); break;
             case '\t': append("\\t"); break;
+            case '\r': append("\\r"); break;
             case 92:   append("\\");  break;
             default:   append(to!string(k));
 		}


### PR DESCRIPTION
Since 2.061 the trie form of the keywords rule can now be compiled with inlining turned on. This is a small fix to make peg.d compile with the current grammar.d. The speed gain with the trie is probably not worth the much longer compile time, but it is a little faster (~10%) at running my grammar. 

Once the new std.uni comes in, there might be a phobos trie implementation to try out. 
