### PR TITLE
Add package.json for using Pegged as a DUB dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "pegged",
+    "description": "Parsing Expression Grammar (PEG) generator",
+    "copyright": "Copyright © 2012-2013, Philippe Sigaud",
+    "license": "Boost",
+    "authors": [ "Philippe Sigaud" ],
+    "sourceFiles": [
+        "pegged/peg.d",
+        "pegged/grammar.d",
+        "pegged/parser.d",
+        "pegged/dynamic/grammar.d",
+        "pegged/dynamic/peg.d"
+    ],
+    "importPaths": ["."],
+    "dflags": ["-wi", "-ignore", "-property"],
+    "dflags-gdc": ["-ggdb"],
+    "dflags-ldc": ["-check-printf-calls"],
+}


### PR DESCRIPTION
Adds a minimal package.json file. The library will be compiled as a
source library together with the host project.

Trying to build directly using "dub" currently fails because no main()
is defined. In the future this may be changed to instead build a
static library, but dub needs to be extended for that slightly.

The package file here is basically the same as in #109, but removes
all build type specific flags (dub manages those itself using e.g.
--build=unittest).
