### PR TITLE
Fix endOfLine

### DIFF
--- a/pegged/peg.d
+++ b/pegged/peg.d
@@ -2572,7 +2572,7 @@ unittest // 'keep' unit test
 
 /* ****************** predefined rules ******************** */
 
-alias named!(keywords!("\r\n", "\n", "\r"), "endOfLine") endOfLine; /// predefined end-of-line parser
+alias named!(or!(literal!("\r\n"), literal!("\n"), literal!("\r")), "endOfLine") endOfLine; /// predefined end-of-line parser
 alias endOfLine eol; /// helper alias.
 
 alias or!(literal!(" "), literal!("\t"), literal!("\v")) space; /// predefined space-recognizing parser (space or tabulation).


### PR DESCRIPTION
I have a grammar that uses `<` to ignore spaces. Unfortunately it failed with files that have `\r\n` line endings. I figured out that by this change that spaces are properly ignored and the fix seems correct to me. Why should line endings be keywords?

Anyway, please check carefully.
