### PR TITLE
fix dub build warnings - remove redundant arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "pegged/examples/arithmetic.d"
     ],
     "importPaths": ["."],
-    "dflags": ["-wi", "-ignore", "-property"],
+    "dflags": ["-ignore"],
     "dflags-gdc": ["-ggdb"],
     "dflags-ldc": ["-check-printf-calls"],
 }


### PR DESCRIPTION
- dub enables warnings by default
- property is deprecated and may break building other dub packages
