### PR TITLE
About hidden left-recursion

### DIFF
--- a/pegged/grammar.d
+++ b/pegged/grammar.d
@@ -378,7 +378,7 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
                            ~  "            return " ~ ctfeCode ~ "(p);\n"
                            ~  "        else {\n"
                            ~  "            if (auto s = tuple(" ~ innerName ~ ", p.end) in seed)\n"
-                           ~  "                return *s;"
+                           ~  "                return *s;\n"
                            ~  "            auto current = fail(p);\n"
                            ~  "            seed[tuple(" ~ innerName ~ ", p.end)] = current;\n"
                            ~  "            while(true) {\n"


### PR DESCRIPTION
This is a bit of a bummer. Grammars with hidden left-recursion can be processed and some input will be matched correctly, but it seems that this is input that also would have been matched if the grammar were rewritten to take the hiding optional out of the recursive cycle (thus describing a different language). Input that really depends on hidden left-recursion will not be matched currently.

The out-commented assert in this test is an example of valid but failing input. I have described the mechanics of this in my message to Nicolas Laurent, https://github.com/norswap/autumn_dev/issues/1.

I hope someone smarter than me will see a solution, but I have a feeling it won't be possible to support in linear time, and probably add a lot of complexity...

Still there is the possibility that I have completely overlooked something, this is not really my field :-)