### PR TITLE
Fixes #166.

### DIFF
--- a/pegged/dev/introspection.d
+++ b/pegged/dev/introspection.d
@@ -5,7 +5,6 @@ module pegged.dev.introspection;
 
 import std.typecons;
 
-import pegged.grammar;
 import pegged.parser;
 
 /**
@@ -58,7 +57,7 @@ Returns for all grammar rule:
 
 This kind of potential problem can be detected statically and should be transmitted to the grammar designer.
 */
-RuleInfo[string] ruleInfo(ParseTree p)
+pure RuleInfo[string] ruleInfo(ParseTree p)
 {
     if (p.name == "Pegged")
         return ruleInfo(p.children[0]);
@@ -206,11 +205,9 @@ RuleInfo[string] ruleInfo(ParseTree p)
                 else
                     return NullMatch.no;
             case "Pegged.CharClass":
-                return NullMatch.no;
             case "Pegged.ANY":
                 return NullMatch.no;
             case "eps":
-                return NullMatch.yes;
             case "eoi":
                 return NullMatch.yes;
             default:
@@ -223,15 +220,6 @@ RuleInfo[string] ruleInfo(ParseTree p)
         switch (p.name)
         {
             case "Pegged.Expression": // choice expressions loop whenever one of their components can loop
-                foreach(seq; p.children)
-                {
-                    auto nm = infiniteLooping(seq);
-                    if (nm == InfiniteLoop.yes)
-                        return InfiniteLoop.yes;
-                    if (nm == InfiniteLoop.indeterminate)
-                        return InfiniteLoop.indeterminate;
-                }
-                return InfiniteLoop.no;
             case "Pegged.Sequence": // sequence expressions can loop when one of their components can loop
                 foreach(seq; p.children)
                 {
@@ -259,13 +247,9 @@ RuleInfo[string] ruleInfo(ParseTree p)
                 else
                     return infiniteLooping(p.children[0]);
             case "Pegged.Literal":
-                return InfiniteLoop.no;
             case "Pegged.CharClass":
-                return InfiniteLoop.no;
             case "Pegged.ANY":
-                return InfiniteLoop.no;
             case "eps":
-                return InfiniteLoop.no;
             case "eoi":
                 return InfiniteLoop.no;
             default:
@@ -294,9 +278,9 @@ RuleInfo[string] ruleInfo(ParseTree p)
                     auto lr = leftRecursion(seq, target);
                     if (lr == LeftRecursive.direct)
                         return (i == 0 ? LeftRecursive.direct : LeftRecursive.hidden);
-                    else if (lr == LeftRecursive.hidden || lr == LeftRecursive.indirect)
+                    if (lr == LeftRecursive.hidden || lr == LeftRecursive.indirect)
                         return lr;
-                    else if (nullMatching(seq) == NullMatch.yes)
+                    if (nullMatching(seq) == NullMatch.yes)
                         continue;
                     else
                         return LeftRecursive.no;
@@ -305,69 +289,55 @@ RuleInfo[string] ruleInfo(ParseTree p)
             case "Pegged.Prefix":
                 return leftRecursion(p.children[$-1], target);
             case "Pegged.Suffix":
-                return leftRecursion(p.children[0], target);
             case "Pegged.Primary":
                 return leftRecursion(p.children[0], target);
             case "Pegged.RhsName":
                 if (p.matches[0] == target) // ?? Or generateCode(p) ?
                     return LeftRecursive.direct;
-                else if (((p.matches[0] in maybeLeftRecursive) && (maybeLeftRecursive[p.matches[0]])) ||
-                         ((p.matches[0] in rules) && (leftRecursion(rules[p.matches[0]], target) != LeftRecursive.no)))
+                if (((p.matches[0] in maybeLeftRecursive) && (maybeLeftRecursive[p.matches[0]])) ||
+                    ((p.matches[0] in rules) && (leftRecursion(rules[p.matches[0]], target) != LeftRecursive.no)))
                     return LeftRecursive.indirect;
-                else
-                    return LeftRecursive.no;
-            case "Pegged.Literal":
-                return LeftRecursive.no;
-            case "Pegged.CharClass":
-                return LeftRecursive.no;
-            case "Pegged.ANY":
-                return LeftRecursive.no;
-            case "eps":
-                return LeftRecursive.no;
-            case "eoi":
                 return LeftRecursive.no;
             default:
                 return LeftRecursive.no;
         }
     }
 
+    // Initialize rules and result.
     foreach(definition; p.children)
         if (definition.name == "Pegged.Definition")
         {
             rules[definition.matches[0]] = definition.children[2];
             result[definition.matches[0]] = RuleInfo(Recursive.no, LeftRecursive.no,
-                                                     NullMatch.indeterminate,InfiniteLoop.indeterminate);
+                                                     NullMatch.indeterminate, InfiniteLoop.indeterminate);
         }
 
-    auto rec = recursions(callGraph(p));
-    foreach(rule, recursionType; rec)
-        if (rule in result) // external rules are in rec, but not in result
+    // Detect recursions.
+    foreach(rule, recursionType; recursions(callGraph(p)))
+        if (rule in result) // external rules are in recursions, but not in result
             result[rule].recursion = recursionType;
 
+    // Detect left-recursions.
     foreach(name, tree; rules)
-    {
         if (result[name].recursion != Recursive.no)
-        {
             result[name].leftRecursion = leftRecursion(tree, name);
-        }
-    }
 
+    // Detect null matches.
     bool changed = true;
-
     while(changed) // while something new happened, the process is not over
     {
         changed = false;
         foreach(name, tree; rules)
             if (result[name].nullMatch == NullMatch.indeterminate) // not done yet
             {
-                result [name].nullMatch = nullMatching(tree); // try to find if it's null-matching
+                result[name].nullMatch = nullMatching(tree); // try to find if it's null-matching
                 if (result[name].nullMatch != NullMatch.indeterminate)
                     changed = true;
             }
     }
 
+    // Detect infinite loops.
     changed = true;
-
     while(changed) // while something new happened, the process is not over
     {
         changed = false;


### PR DESCRIPTION
Man, did I have to concentrate on this one. But satisfying once it finally works.

I'll be using the `cycle` array later on to place the wrapping code around select left-recursive expressions in grammar.d.