### PR TITLE
Left recursion

### DIFF
--- a/pegged/dev/introspection.d
+++ b/pegged/dev/introspection.d
@@ -44,7 +44,8 @@ struct RuleInfo
     Recursive recursion; /// Is the rule recursive?
     LeftRecursive leftRecursion; /// Is the rule left-recursive?
     NullMatch nullMatch; /// Can the rule succeed while consuming nothing?
-    InfiniteLoop infiniteLoop; /// Can the rule loop while indefinitely, while consuming nothing?
+    InfiniteLoop infiniteLoop; /// Can the rule loop indefinitely, while consuming nothing?
+    string[] leftRecursiveCycle; /// The path of rules traversed before indirect left-recursion recurses.
 }
 
 /**
@@ -323,9 +324,8 @@ pure RuleInfo[string] ruleInfo(ParseTree p)
     foreach(name, tree; rules)
         if (result[name].recursion != Recursive.no)
         {
-            string[] cycle;
-            cycle ~= name;
-            result[name].leftRecursion = leftRecursion(tree, cycle);
+            result[name].leftRecursiveCycle ~= name;
+            result[name].leftRecursion = leftRecursion(tree, result[name].leftRecursiveCycle);
         }
 
     // Detect null matches.

--- a/pegged/grammar.d
+++ b/pegged/grammar.d
@@ -2430,7 +2430,7 @@ unittest // Memoization testing
     assert(!is(typeof(Test2.memo)));
 
     ParseTree result1 = Test1("aaaaaaac");      // Memo + Runtime
-    enum ParseTree result2 = Test1("aaaaaaac"); // Memo + Compile-time
+    enum ParseTree result2 = Test1("aaaaaaac"); // Memo + Compile-time. Note: there is no actual memoization at CT.
     ParseTree result3 = Test2("aaaaaaac");      // No memo + Runtime
     enum ParseTree result4 = Test2("aaaaaaac"); // No memo + Compile-time
 

--- a/pegged/grammar.d
+++ b/pegged/grammar.d
@@ -141,7 +141,6 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
 
     string[] stoppers = leftRecursionStoppers();
 
-
     string generateCode(ParseTree p, string propagatedName = "")
     {
         string result;
@@ -2699,7 +2698,7 @@ unittest // Left- and right-recursion (is right-associative!)
     assert(result.matches == ["n", "+", "n", "+", "n", "+", "n"]);
 }
 
-unittest // Hidden left-recursion --- Possibly fails on valid input.
+unittest // Hidden left-recursion
 {
     enum HiddenLeft = `
       Test:

--- a/pegged/grammar.d
+++ b/pegged/grammar.d
@@ -407,7 +407,12 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
                            ~  "    {\n"
                            ~  "        static TParseTree[size_t /*position*/] seed;\n"
                            ~  "        if(__ctfe)\n"
+                           ~  "        {\n"
+                           ~  (stoppers.canFind(shortName) ?
+                              "            assert(false, \"" ~ shortName ~ " is left-recursive, which is not supported "
+                                                           "at compile-time. Consider using asModule().\");" : "")
                            ~  "            return " ~ ctfeCode ~ "(p);\n"
+                           ~  "        }\n"
                            ~  "        else\n"
                            ~  "        {\n"
                            ~  (stoppers.canFind(shortName) ?


### PR DESCRIPTION
Hi Philippe,

This properly supports hidden left-recursion, and also adds support for left-recursion in memoizing parsers. As far as code is concerned I think we are pretty much there -- I don't expect much changes after this. What could still be added is control over left/right associativity, but I plan to play with this first to see if I need it.

What I couldn't get to work is support for left-recursion at compile-time due to the error "cannot read static variable seed at compile time". I don't really understand why, but I noticed that you are not using memo at compile time either. So I figure I am in good company. Nevertheless, when left-recursion is detected to occur at compile time, compilation stops with an assertion error and explanation.

Parse speed for non-left-recursive rules should now be back at the level before I started contributing to Pegged, so the overhead at parse-time is minimal. The cost is payed at compile-time, with an introspection of the grammar. A template argument may be desirable to cut this overhead out for grammars that the developer knows for sure are not left-recursive, by which compilation of left-recursion support would be optional. Anyone could do this though, and I don't have direct plans to add it. Also, I don't use all the grammar properties that the introspection module gathers, so some speedup may be gained by configuring the unused parts out. No plans there either.

I plan to apply Pegged in an experimental project of mine in the new year. When I'm confident that left-recursion support works well in production, I can adjust the documentation of Pegged, comment on the odd issue regarding left-recursion and maybe add a wiki page on the implementation with references. When that's done maybe you feel like bumping the version of Pegged, and have a little release party on the announce-forum :-)

Season's greetings,
Bastiaan.