### PR TITLE
Fix blocking of memoization.

### DIFF
--- a/pegged/grammar.d
+++ b/pegged/grammar.d
@@ -302,6 +302,15 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
         if (withMemo == Memoization.yes)
             result ~= "
         memo = null;";
+        string[] visited = [];
+        foreach (cycle; grammarInfo.leftRecursiveCycles)
+            foreach (rule; cycle)
+                if (!visited.canFind(rule))
+                {
+                    visited ~= rule;
+                    result ~= "
+        blockMemo_" ~ rule ~ "_atPos = null;";
+                }
         if (composedGrammars.length > 0)
             result ~= "
         import std.traits;";
@@ -322,7 +331,6 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
         string generateBlockers()
         {
             string result;
-            import std.algorithm.iteration;
             string[] visited = [];
             foreach (cycle; grammarInfo.leftRecursiveCycles)
                 foreach (rule; cycle)

--- a/pegged/grammar.d
+++ b/pegged/grammar.d
@@ -258,8 +258,7 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
     {
         string result;
         foreach (rule; stoppers[stopper] ~ stopper)
-            result ~= "            if (!blockMemo_" ~ rule ~ "_atPos.canFind(p.end))\n"
-                      "                blockMemo_" ~ rule ~ "_atPos ~= p.end;\n";
+            result ~= "            blockMemo_" ~ rule ~ "_atPos ~= p.end;\n";
         return result;
     }
 
@@ -268,7 +267,6 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
     {
         string result;
         foreach (rule; stoppers[stopper] ~ stopper)
-            // TODO investigate if values are always unique.
             // TODO investigate if p.end is always the last element.
             result ~= "                    assert(blockMemo_" ~ rule ~ "_atPos.canFind(p.end));\n"
                       "                    remove(blockMemo_" ~ rule ~ "_atPos, countUntil(blockMemo_" ~ rule ~ "_atPos, p.end));\n";


### PR DESCRIPTION
Calls to rules can nest, therefore blocking and unblocking needs to be balanced. This causes the static block counters to be empty after a successful parse, which is good. Nevertheless, a failed parse could leave an unclean state behind, which is now cleaned up in forgetMemo().