### PR TITLE
Tracer: example, dub option, compile fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,14 @@
     "importPaths": ["."],
     "dflags": ["-ignore"],
     "dflags-gdc": ["-ggdb"],
-    "dflags-ldc": ["-check-printf-calls"]
+    "dflags-ldc": ["-check-printf-calls"],
+    "configurations": [
+        {
+			"name": "default",
+		},
+        {
+			"name": "tracer",
+			"versions": ["tracer"],
+		}
+	]
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "dflags-ldc": ["-check-printf-calls"],
     "configurations": [
         {
-			"name": "default",
-		},
+            "name": "default",
+        },
         {
-			"name": "tracer",
-			"versions": ["tracer"],
-		}
-	]
+            "name": "tracer",
+            "versions": ["tracer"],
+        }
+    ]
 }

--- a/pegged/examples/extended_pascal/dub.json
+++ b/pegged/examples/extended_pascal/dub.json
@@ -22,11 +22,11 @@
     "configurations": [
         {
             "name": "default",
-			"targetType": "executable"
+            "targetType": "executable"
         },
         {
             "name": "tracer",
-			"targetType": "executable",
+            "targetType": "executable",
             "versions": ["tracer"],
             "subConfigurations": {
                 "pegged": "tracer"

--- a/pegged/examples/extended_pascal/dub.json
+++ b/pegged/examples/extended_pascal/dub.json
@@ -1,14 +1,14 @@
 {
-	"name": "parse_ep",
-	"authors": [
-		"Bastiaan Veelo"
-	],
-	"dependencies": {
-		"pegged":  {
+    "name": "parse_ep",
+    "authors": [
+        "Bastiaan Veelo"
+    ],
+    "dependencies": {
+        "pegged":  {
             "version": "*",
             "path": "../../.."
         },
-	},
+    },
     "preGenerateCommands": [
         "rdmd -I$PEGGED_PACKAGE_DIR source/make.d"
     ],
@@ -16,7 +16,21 @@
         "source/make.d",
         "source/epgrammar.d"
     ],
-	"description": "Example parser for Extended Pascal.",
-	"copyright": "Copyright © 2017, Bastiaan Veelo",
-	"license": "Boost License 1.0"
+    "description": "Example parser for Extended Pascal.",
+    "copyright": "Copyright © 2017, Bastiaan Veelo",
+    "license": "Boost License 1.0",
+    "configurations": [
+        {
+            "name": "default",
+			"targetType": "executable"
+        },
+        {
+            "name": "tracer",
+			"targetType": "executable",
+            "versions": ["tracer"],
+            "subConfigurations": {
+                "pegged": "tracer"
+            }
+        }
+    ]
 }

--- a/pegged/examples/extended_pascal/source/app.d
+++ b/pegged/examples/extended_pascal/source/app.d
@@ -22,6 +22,26 @@ int main(string[] args)
         return 1;
     }
 
+
+    version (tracer)
+    {
+        import std.experimental.logger;
+        import std.algorithm : startsWith;
+        sharedLog = new TraceLogger("TraceLog.txt");
+        bool cond (string ruleName)
+        {
+            static startTrace = false;
+            if (ruleName.startsWith("EP.FunctionDeclaration"))
+                startTrace = true;
+            return startTrace && ruleName.startsWith("EP");
+        }
+        // Various ways of turning logging on and of:
+        //setTraceConditionFunction(&cond);
+        setTraceConditionFunction(ruleName => ruleName.startsWith("EP"));
+        //traceAll;
+    }
+
+
     auto parseTree = EP(readText(args[1]));
 
     if (html) {

--- a/pegged/peg.d
+++ b/pegged/peg.d
@@ -164,6 +164,8 @@ version (tracer)
         {
             super(fn);
         }
+        import std.concurrency : Tid;
+        import std.datetime : SysTime;
         override protected void beginLogMsg(string file, int line, string funcName,
             string prettyFuncName, string moduleName, LogLevel logLevel,
             Tid threadId, SysTime timestamp, Logger logger)


### PR DESCRIPTION
Fixes deprecation error in peg.d for `version(tracer)`.

I am new to dub configurations, I had to introduce a "default" configuration to prevent the "tracer" option to be automatically selected.