### PR TITLE
Implement longest match parser. Closes PhilippeSigaud/Pegged#218.

### DIFF
--- a/pegged/examples/peggedgrammar.d
+++ b/pegged/examples/peggedgrammar.d
@@ -9,7 +9,9 @@ Pegged:
 # Syntactic rules:
 Grammar      <- Spacing GrammarName Definition+ :eoi
 Definition   <- LhsName Arrow Expression
-Expression   <- :OR? Sequence (:OR Sequence)*
+Expression   <- FirstExpression / LongestExpression
+FirstExpression   <- :OR? Sequence (:OR Sequence)+
+LongestExpression <- :(OR / LONGEST_OR)? Sequence (:LONGEST_OR Sequence)*
 Sequence     <- Prefix+
 Prefix       <- (POS / NEG / FUSE / DISCARD / KEEP / DROP / PROPAGATE)* Suffix
 Suffix       <- Primary (OPTION / ZEROORMORE / ONEORMORE / Action)*
@@ -66,6 +68,7 @@ SPACEARROW   <- '<' Spacing
 ACTIONARROW  <- '<' Action Spacing
 
 OR           <- '/' Spacing
+LONGEST_OR   <- '|' Spacing
 
 POS          <- '&' Spacing
 NEG          <- '!' Spacing

--- a/pegged/introspection.d
+++ b/pegged/introspection.d
@@ -193,7 +193,10 @@ pure GrammarInfo grammarInfo(ParseTree p)
     {
         switch (p.name)
         {
-            case "Pegged.Expression": // choice expressions null-match whenever one of their components can null-match
+            case "Pegged.Expression":
+                return nullMatching(p.children[0]);
+            case "Pegged.FirstExpression",
+                 "Pegged.LongestExpression": // choice expressions null-match whenever one of their components can null-match
                 foreach(seq; p.children)
                     if (nullMatching(seq) == NullMatch.yes)
                         return NullMatch.yes;
@@ -294,7 +297,10 @@ pure GrammarInfo grammarInfo(ParseTree p)
         import std.algorithm.searching: countUntil;
         switch (p.name)
         {
-            case "Pegged.Expression": // Choices are left-recursive if any choice is left-recursive
+            case "Pegged.Expression":
+                return leftRecursion(p.children[0], cycle);
+            case "Pegged.FirstExpression",
+                 "Pegged.LongestExpression": // Choices are left-recursive if any choice is left-recursive
                 // Because memoized left-recursion handling needs to know about all left-recursive cycles,
                 // we consider all choices, not just one.
                 auto any_lr = LeftRecursive.no;


### PR DESCRIPTION
The `longest_match!()` parser is like the `or!()` parser, except that all rules are tried and the one producing the longest match is taken. I have extended the PEG grammar to let `|` denote the longest match choice operator, besides the standard `/` prioritised choice. Unfortunately, the `Expression*` rules in `peggedgrammar.d` have become a tad convoluted; at first I used negative lookahead, but this I think is better. Alternatively, I could have used `Expression <- Expression | LongestExpression`.

I hope you think this is worth it. With this change I _am_ able to parse a complete EP source file that is currently in production, with non-standard language extensions. The `epgrammar.d` changes for this I will commit later. You may bump the version before or after that, but maybe let me document this extension first?