### PR TITLE
EP grammar changes.

### DIFF
--- a/pegged/examples/extended_pascal/source/epgrammar.d
+++ b/pegged/examples/extended_pascal/source/epgrammar.d
@@ -12,6 +12,10 @@
 // 1 - Retain layout and comments.
 // 2 - Reorder choices from long to short in order to get the longest match.
 // 3 - Identify certain identifiers in the translator.
+//
+// In addition, the following Prospero extensions have been added, marked with Prospero
+// 1 - Type viewing (casting) with the '::' operator.
+// 2 - Labels can be identifiers
 
 enum EPgrammar = `
 EP:
@@ -35,22 +39,24 @@ EP:
     ImplementationDirective <- "implementation"i
 
 # 6.1.7 (complete)
-    SignedNumber    <- SignedInteger / SignedReal
+    SignedNumber    <- SignedReal / SignedInteger       # BNV changed order: real match is always longer dan integer match.
     SignedReal      <~ Sign? UnsignedReal
     SignedInteger   <~ Sign? UnsignedInteger
-    UnsignedNumber  <- UnsignedInteger / UnsignedReal
+    UnsignedNumber  <- UnsignedReal / UnsignedInteger   # BNV changed order: real match is always longer dan integer match.
     Sign            <- [-+]
-    UnsignedReal    <~ DigitSequence "." FractionalPart ( [eE] ScaleFactor )? / DigitSequence [eE] ScaleFactor
+    UnsignedReal    <~ DigitSequence "." FractionalPart ( [eE] ScaleFactor )? | DigitSequence [eE] ScaleFactor
     UnsignedInteger <- DigitSequence
     FractionalPart  <- DigitSequence
     ScaleFactor     <~ Sign? DigitSequence
     DigitSequence   <~ digits
-    Number          <~ SignedNumber / Sign? ( DigitSequence "." / "." FractionalPart ) ( [eE] ScaleFactor )?
+    Number          <~ SignedNumber | Sign? ( DigitSequence "." / "." FractionalPart ) ( [eE] ScaleFactor )?
     ExtendedDigit   <- Digit / Letter
     ExtendedNumber  <- UnsignedInteger "#" ExtendedDigit+
 
 # 6.1.8 (complete)
-    Label   <- DigitSequence
+#    Label   <- DigitSequence
+# Prospero supports identifiers as labels:
+    Label   <- DigitSequence / Identifier
 
 # 6.1.9 (complete)
     CharacterString <- "'" StringElement* "'"
@@ -60,7 +66,7 @@ EP:
 
 # 6.1.10 Token separators
     Spacing         <~ blank+   # BNV Do not discard spacing.
-    _               <- ( Spacing / TrailingComment / InlineComment )+
+    _               <- ( Spacing / TrailingComment / InlineComment )*
     Comment         <- ( :Spacing / TrailingComment / InlineComment )+
     CommentOpen     <-  "{" / "(*"
     CommentClose    <-  "}" / "*)"
@@ -69,24 +75,24 @@ EP:
     TrailingComment <- CommentOpen CommentContent CommentClose &endOfLine
 
 # 6.2.1 (complete)
-    Block                               <- ImportPart ( _? LabelDeclarationPart / ConstantDefinitionPart / TypeDefinitionPart / VariableDeclarationPart / ProcedureAndFunctionDeclarationPart )* _? StatementPart _?
-    ImportPart                          <- (:IMPORT _ ( ImportSpecification _? :";" _? )+ )?
-    LabelDeclarationPart                <- :LABEL _ Label ( _? "," _? Label )* _? :";" _?
-    ConstantDefinitionPart              <- :CONST _ ( ConstantDefinition _? :";" _? )+
-    TypeDefinitionPart                  <- :TYPE _ ( ( TypeDefinition / SchemaDefinition) _? :";" _? )+
-    VariableDeclarationPart             <- :VAR _ ( VariableDeclaration _? :";" _? )+
-    ProcedureAndFunctionDeclarationPart <- ( ( ProcedureDeclaration / FunctionDeclaration ) _? :";" _? )*
+    Block                               <- ImportPart ( _ ( LabelDeclarationPart / ConstantDefinitionPart / TypeDefinitionPart / VariableDeclarationPart / ProcedureAndFunctionDeclarationPart ) )* _ StatementPart _
+    ImportPart                          <- (:IMPORT _ ( ImportSpecification _ :";" _ )+ )?
+    LabelDeclarationPart                <- :LABEL _ Label ( _ "," _ Label )* _ :";" _
+    ConstantDefinitionPart              <- :CONST _ ( ConstantDefinition _ :";" _ )+
+    TypeDefinitionPart                  <- :TYPE _ ( ( TypeDefinition / SchemaDefinition) _ :";" _ )+
+    VariableDeclarationPart             <- :VAR _ ( VariableDeclaration _ :";" _ )+
+    ProcedureAndFunctionDeclarationPart <- ( ( ProcedureDeclaration / FunctionDeclaration ) _ :";" _ )*
     StatementPart                       <- CompoundStatement
 
 # 6.3.1 (complete)
-    ConstantDefinition  <- Identifier _? "=" _? ConstantExpression
+    ConstantDefinition  <- Identifier _ "=" _ ConstantExpression
     ConstantIdentifier  <- Identifier
-    ConstantName        <- ( ImportedInterfaceIdentifier _? DOT _? )? ConstantIdentifier
+    ConstantName        <- ( ImportedInterfaceIdentifier _ DOT _ )? ConstantIdentifier
 
 # 6.4.1 (complete)
-    TypeDefinition      <- BNVTypeDefName _? "=" _? TypeDenoter
-    TypeDenoter         <- :(BINDABLE _ )? ( DiscriminatedSchema / NewType / TypeInquiry / TypeName ) _? InitialStateSpecifier? # BNV Put DiscriminatedSchema first, TypeName last.
-    NewType             <- NewStructuredType / NewOrdinalType / NewPointerType / RestrictedType # BNV Put NewStructuredType first.
+    TypeDefinition      <- BNVTypeDefName _ "=" _ TypeDenoter
+    TypeDenoter         <- :(BINDABLE _ )? ( TypeName | NewType | TypeInquiry | DiscriminatedSchema ) _ InitialStateSpecifier?
+    NewType             <- NewOrdinalType | NewStructuredType | NewPointerType | RestrictedType
     #SimpleTypeName      <- TypeName    # BNV Semantic only
     StructuredTypeName  <- ArrayTypeName / RecordTypeName / SetTypeName / FileTypeName
     ArrayTypeName       <- TypeName
@@ -95,24 +101,24 @@ EP:
     FileTypeName        <- TypeName
     #PointerTypeName     <- TypeName    # BNV Semantic only
     TypeIdentifier      <- Identifier
-    TypeName            <- ( ImportedInterfaceIdentifier _? DOT _? )? TypeIdentifier
+    TypeName            <- ( ImportedInterfaceIdentifier _ DOT _ )? TypeIdentifier
 #BNV extensions
     BNVTypeDefName      <- Identifier
 
 # 6.4.2.1 (complete)
     #SimpleType          <- OrdinalType / RealTypeName / ComplexTypeName    # BNV Semantic only
-    OrdinalType         <- NewOrdinalType / OrdinalTypeName / TypeInquiry / DiscriminatedSchema
-    NewOrdinalType      <- EnumeratedType / SubrangeType
+    OrdinalType         <- NewOrdinalType | OrdinalTypeName | TypeInquiry | DiscriminatedSchema
+    NewOrdinalType      <- EnumeratedType | SubrangeType
     OrdinalTypeName     <- TypeName
     #RealTypeName        <- TypeName    # BNV Semantic only
     #ComplexTypeName     <- TypeName    # BNV Semantic only
 
 # 6.4.2.3 (complete)
-    EnumeratedType      <- "(" _? IdentifierList _? ")"
-    IdentifierList      <- Identifier ( _? COMMA _? Identifier )*
+    EnumeratedType      <- "(" _ IdentifierList _ ")"
+    IdentifierList      <- Identifier ( _ COMMA _ Identifier )*
 
 # 6.4.2.4 (complete)
-    SubrangeType        <- SubrangeBound _? ".." _? SubrangeBound
+    SubrangeType        <- SubrangeBound _ ".." _ SubrangeBound
     SubrangeBound       <- Expression
 
 # 6.4.2.5 (complete)
@@ -120,11 +126,11 @@ EP:
 
 # 6.4.3.1 (complete)
     #StructuredType          <- NewStructuredType / StructuredTypeName  # BNV Semantic only
-    NewStructuredType       <- :PACKED? _? UnpackedStructuredType
+    NewStructuredType       <- :PACKED? _ UnpackedStructuredType
     UnpackedStructuredType  <- ArrayType / RecordType / SetType / FileType
 
 # 6.4.3.2 (complete)
-    ArrayType           <- :ARRAY _ "[" _? IndexType ( _? COMMA _? IndexType )* _? "]" _ :OF _ ComponentType
+    ArrayType           <- :ARRAY _ "[" _ IndexType ( _ COMMA _ IndexType )* _ "]" _ :OF _ ComponentType
     IndexType           <- OrdinalType
     ComponentType       <- TypeDenoter
 
@@ -132,19 +138,19 @@ EP:
 
 # 6.4.3.4 (complete)
     RecordType          <- :RECORD _ FieldList _ :END
-    FieldList           <- ( ( FixedPart ( _? ";" _? VariantPart )? / VariantPart ) _? ";"? )?
-    FixedPart           <- RecordSection ( _? ";" _? RecordSection )*
-    RecordSection       <- IdentifierList _? ":" _? TypeDenoter
+    FieldList           <- ( ( FixedPart ( _ ";" _ VariantPart )? / VariantPart ) _ ";"? )?
+    FixedPart           <- RecordSection ( _ ";" _ RecordSection )*
+    RecordSection       <- IdentifierList _ ":" _ TypeDenoter
     FieldIdentifier     <- Identifier
-    VariantPart         <- :CASE _ VariantSelector _ :OF _ ( VariantListElement ( _? ";" _? VariantListElement )* ( _? ":"? _? VariantPartCompleter )? / VariantPartCompleter )
-    VariantListElement  <- CaseConstantList _? ":" _? VariantDenoter
+    VariantPart         <- :CASE _ VariantSelector _ :OF _ ( VariantListElement ( _ ";" _ VariantListElement )* ( _ ":"? _ VariantPartCompleter )? | VariantPartCompleter )
+    VariantListElement  <- CaseConstantList _ ":" _ VariantDenoter
     VariantPartCompleter    <- OTHERWISE _ VariantDenoter
-    VariantDenoter      <- "(" _? FieldList _? ")"
-    VariantSelector     <- ( TagField _? ":" _? )? TagType / DiscriminantIdentifier
+    VariantDenoter      <- "(" _ FieldList _ ")"
+    VariantSelector     <- ( TagField _ ":" _ )? TagType | DiscriminantIdentifier
     TagField            <- Identifier
     TagType             <- OrdinalTypeName
-    CaseConstantList    <- CaseRange ( _? "," _? CaseRange )*
-    CaseRange           <- CaseConstant ( _? ".." _? CaseConstant )?
+    CaseConstantList    <- CaseRange ( _ "," _ CaseRange )*
+    CaseRange           <- CaseConstant ( _ ".." _ CaseConstant )?
     CaseConstant        <- ConstantExpression
 
 # 6.4.3.5 (complete)
@@ -152,24 +158,24 @@ EP:
     BaseType            <- OrdinalType
 
 # 6.4.3.6 (complete)
-    FileType            <- :FILE _ ( "[" _? IndexType _? "]" _? )? :OF _ ComponentType
+    FileType            <- :FILE _ ( "[" _ IndexType _ "]" _ )? :OF _ ComponentType
 
 # 6.4.4 (complete)
     #PointerType         <- NewPointerType / PointerTypeName    # BNV Semantic only
-    NewPointerType      <- :"^" _? DomainType
-    DomainType          <- TypeName / SchemaName
+    NewPointerType      <- :"^" _ DomainType
+    DomainType          <- TypeName | SchemaName
 
 # 6.4.7 (complete)
-    SchemaDefinition            <- ( Identifier _? "=" _? SchemaName ) / ( Identifier _? FormalDiscriminantPart _? "=" _? TypeDenoter )
-    FormalDiscriminantPart      <- "(" _? DiscriminantSpecification ( _? ";" _? DiscriminantSpecification )* _? ")"
-    DiscriminantSpecification   <- IdentifierList _? ":" _? OrdinalTypeName
+    SchemaDefinition            <- ( Identifier _ "=" _ SchemaName ) | ( Identifier _ FormalDiscriminantPart _ "=" _ TypeDenoter )
+    FormalDiscriminantPart      <- "(" _ DiscriminantSpecification ( _ ";" _ DiscriminantSpecification )* _ ")"
+    DiscriminantSpecification   <- IdentifierList _ ":" _ OrdinalTypeName
     DiscriminantIdentifier      <- Identifier
     SchemaIdentifier            <- Identifier
-    SchemaName                  <- ( ImportedInterfaceIdentifier _? "." _? )? SchemaIdentifier
+    SchemaName                  <- ( ImportedInterfaceIdentifier _ "." _ )? SchemaIdentifier
 
 # 6.4.8 (complete)
-    DiscriminatedSchema     <- SchemaName _? ActualDiscriminantPart
-    ActualDiscriminantPart  <- "(" _? DiscriminantValue _? ( "," _? DiscriminantValue _? )* ")"
+    DiscriminatedSchema     <- SchemaName _ ActualDiscriminantPart
+    ActualDiscriminantPart  <- "(" _ DiscriminantValue _ ( "," _ DiscriminantValue _ )* ")"
     DiscriminantValue       <- Expression
 
 # 6.4.9 (complete)
@@ -177,87 +183,89 @@ EP:
     TypeInquiryObject   <- VariableName / ParameterIdentifier
 
 # 6.5.1 (complete)
-    VariableDeclaration <- IdentifierList _? ":" _? TypeDenoter
+    VariableDeclaration <- IdentifierList _ ":" _ TypeDenoter
     VariableIdentifier  <- Identifier
-    VariableName        <- ( ImportedInterfaceIdentifier _? DOT _? )? VariableIdentifier
-    VariableAccess      <- EntireVariable / ComponentVariable / IdentifiedVariable / BufferVariable / SubstringVariable / FunctionIdentifiedVariable
+    VariableName        <- ( ImportedInterfaceIdentifier _ DOT _ )? VariableIdentifier
+#    VariableAccess      <- EntireVariable | ComponentVariable | IdentifiedVariable | BufferVariable | SubstringVariable | FunctionIdentifiedVariable
+# Prospero extension: type viewing.
+    VariableAccess      <- ( EntireVariable | ComponentVariable | IdentifiedVariable | BufferVariable | SubstringVariable | FunctionIdentifiedVariable ) ( _ "::" _ TypeName)?
 
 # 6.5.2 (complete)
     EntireVariable      <- VariableName
 
 # 6.5.3.1 (complete)
-    ComponentVariable   <- IndexedVariable / FieldDesignator
+    ComponentVariable   <- IndexedVariable | FieldDesignator
 
 # 6.5.3.2 (complete)
-    IndexedVariable     <- (ArrayVariable _? "[" _? IndexExpression ( _? "," _? IndexExpression )* _? "]" ) / ( StringVariable _? "[" _? IndexExpression _? "]" )
+    IndexedVariable     <- (ArrayVariable _ "[" _ IndexExpression ( _ "," _ IndexExpression )* _ "]" ) | ( StringVariable _ "[" _ IndexExpression _ "]" )
     ArrayVariable       <- VariableAccess
     StringVariable      <- VariableAccess
     IndexExpression     <- Expression
 
 # 6.5.3.3 (complete)
-    FieldDesignator     <- ( RecordVariable _? "." _? FieldSpecifier ) / FieldDesignatorIdentifier
+    FieldDesignator     <- ( RecordVariable _ "." _ FieldSpecifier ) | FieldDesignatorIdentifier
     RecordVariable      <- VariableAccess
     FieldSpecifier      <- FieldIdentifier
 
 # 6.5.4 (complete)
-    IdentifiedVariable  <- PointerVariable _? :"^"
+    IdentifiedVariable  <- PointerVariable _ :"^"
     PointerVariable     <- VariableAccess
 
 # 6.5.5 (complete)
-    BufferVariable      <- FileVariable _? :"^"
+    BufferVariable      <- FileVariable _ :"^"
     FileVariable        <- VariableAccess
 
 # 6.5.6 (complete)
-    SubstringVariable   <- StringVariable _? "[" _? IndexExpression _? ".." _? IndexExpression _? "]"
+    SubstringVariable   <- StringVariable _ "[" _ IndexExpression _ ".." _ IndexExpression _ "]"
 
 # 6.6 (complete)
     InitialStateSpecifier   <- VALUE _ ComponentValue
 
 # 6.7.1 (complete)
-    ProcedureDeclaration    <- ProcedureHeading _? ";" _? RemoteDirective
-                             / ProcedureIdentification _? ";" _? ProcedureBlock
-                             / ProcedureHeading _? ";" _? ProcedureBlock
+    ProcedureDeclaration    <- ProcedureHeading _ ";" _ RemoteDirective
+                             | ProcedureIdentification _ ";" _ ProcedureBlock
+                             | ProcedureHeading _ ";" _ ProcedureBlock
     ProcedureHeading        <- PROCEDURE _ Identifier ( _ FormalParameterList )?
     ProcedureIdentification <- PROCEDURE _ ProcedureIdentifier
     ProcedureIdentifier     <- Identifier
     ProcedureBlock          <- Block
-    ProcedureName           <- ( ImportedInterfaceIdentifier _? DOT _? )? ProcedureIdentifier
+    ProcedureName           <- ( ImportedInterfaceIdentifier _ DOT _ )? ProcedureIdentifier
 
 # 6.7.2 (complete)
-    FunctionDeclaration         <- FunctionHeading _? ";" _? RemoteDirective
-                                 / FunctionIdentification _? ";" _? FunctionBlock
-                                 / FunctionHeading _? ";" _? FunctionBlock
-    FunctionHeading             <- :FUNCTION _ Identifier ( _ FormalParameterList )? ( _ ResultVariableSpecification )? _? ":" _? ResultType
-    ResultVariableSpecification <- "=" _? Identifier
+    FunctionDeclaration         <- FunctionHeading _ ";" _ RemoteDirective
+                                 | FunctionIdentification _ ";" _ FunctionBlock
+                                 | FunctionHeading _ ";" _ FunctionBlock
+    FunctionHeading             <- :FUNCTION _ Identifier ( _ FormalParameterList )? ( _ ResultVariableSpecification )? _ ":" _ ResultType
+    ResultVariableSpecification <- "=" _ Identifier
     FunctionIdentification      <- :FUNCTION _ FunctionIdentifier
     FunctionIdentifier          <- Identifier
     ResultType                  <- TypeName
     FunctionBlock               <- Block
-    FunctionName                <- ( ImportedInterfaceIdentifier _? DOT _? )? FunctionIdentifier
+    FunctionName                <- ( ImportedInterfaceIdentifier _ DOT _ )? FunctionIdentifier
 
 # 6.7.3.1 (complete)
-    FormalParameterList                 <- "(" _? FormalParameterSection ( _? ";" _? FormalParameterSection )* _? ")"
+    FormalParameterList                 <- "(" _ FormalParameterSection ( _ ";" _ FormalParameterSection )* _ ")"
     FormalParameterSection              <- ValueParameterSpecification
-                                         / VariableParameterSpecification
-                                         / ProceduralParameterSpecification
-                                         / FunctionalParameterSpecification
-                                         / ConformantArrayParameterSpecification    # BNV moved from section 6.7.3.7.1
-    ValueParameterSpecification         <- (PROTECTED _ )? IdentifierList _? ":" _? ParameterForm
-    VariableParameterSpecification      <- (PROTECTED _ )? VAR _ IdentifierList _? ":" _? ParameterForm
-    ParameterForm                       <- TypeName / SchemaName / TypeInquiry
+                                         | VariableParameterSpecification
+                                         | ProceduralParameterSpecification
+                                         | FunctionalParameterSpecification
+                                         | ConformantArrayParameterSpecification    # BNV moved from section 6.7.3.7.1
+    ValueParameterSpecification         <- (PROTECTED _ )? IdentifierList _ ":" _ ParameterForm
+    VariableParameterSpecification      <- (PROTECTED _ )? VAR _ IdentifierList _ ":" _ ParameterForm
+    ParameterForm                       <- TypeName | SchemaName | TypeInquiry
     ParameterIdentifier                 <- Identifier
     ProceduralParameterSpecification    <- ProcedureHeading
     FunctionalParameterSpecification    <- FunctionHeading
 
 # 6.7.3.7.1
 #    FormalParameterSection                  <- ConformantArrayParameterSpecification   # BNV Moved to section 6.7.3.1
-    ConformantArrayParameterSpecification   <- ( PROTECTED _ )? ( ValueConformantArraySpecification / VariableConformantArraySpecification )
-    ValueConformantArraySpecification       <- IdentifierList _? ":" _? ConformantArrayForm
-    VariableConformantArraySpecification    <- VAR _ IdentifierList _? ":" _? ConformantArrayForm
+    ConformantArrayParameterSpecification   <- ( PROTECTED _ )? ( ValueConformantArraySpecification | VariableConformantArraySpecification )
+    ValueConformantArraySpecification       <- IdentifierList _ ":" _ ConformantArrayForm
+    VariableConformantArraySpecification    <- VAR _ IdentifierList _ ":" _ ConformantArrayForm
     ConformantArrayForm                     <- PackedConformantArrayForm / UnpackedConformantArrayForm
-    PackedConformantArrayForm               <- "packed"i _ "array"i _? "[" _? IndexTypeSpecification _? "]" _? "of"i _? TypeName
-    UnpackedConformantArrayForm             <- "array"i _? "[" _? IndexTypeSpecification ( _? ";" _? IndexTypeSpecification )* _? "]" _? "of"i _? TypeName
-    IndexTypeSpecification                  <- Identifier _? ".." _? Identifier _? ":" _? OrdinalTypeName
+    PackedConformantArrayForm               <- PACKED _ ARRAY _ "[" _ IndexTypeSpecification _ "]" _ OF _ TypeName
+    UnpackedConformantArrayForm             <- ARRAY _ "[" _ IndexTypeSpecification ( _ ";" _ IndexTypeSpecification )* _ "]" _ OF _ TypeName
+    IndexTypeSpecification                  <- Identifier _ ".." _ Identifier _ ":" _ OrdinalTypeName
 # TODO mistake in standard?
 #    Primary                                 <- BoundIdentifier
 #    BoundIdentifier                         <- Identifier
@@ -265,38 +273,38 @@ EP:
 # 6.7.5 Required procedures TODO
 
 # 6.7.5.5 (complete)
-    ReadstrParameterList    <- "(" _? StringExpression _? "," _? VariableAccess ( _? "," _? VariableAccess )* _? ")"
+    ReadstrParameterList    <- "(" _ StringExpression _ "," _ VariableAccess ( _ "," _ VariableAccess )* _ ")"
     StringExpression        <- Expression
-    WritestrParameterList   <- "(" _? StringVariable _? "," _? WriteParameter ( _? "," _? WriteParameter )* _? ")"
+    WritestrParameterList   <- "(" _ StringVariable _ "," _ WriteParameter ( _ "," _ WriteParameter )* _ ")"
 
 # 6.7.6 Required functions TODO
 
 # 6.8.1 (complete)
-    Expression          <- SimpleExpression ( _? RelationalOperator _? SimpleExpression)?
-    SimpleExpression    <- Sign? _? Term ( _? AddingOperator _? Term )*
-    Term                <- Factor ( _? MultiplyingOperator _? Factor )*
-    Factor              <- Primary ( _? ExponentiatingOperator _? Primary )?
-    Primary             <- UnsignedConstant
-                         / SetConstructor
-                         / "(" _? Expression _? ")"
-                         / NOT _? Primary
-                         / StructuredValueConstructor
-                         / FunctionAccess               # BNV Moved after StructuredValueConstructor
-                         / ConstantAccess               # BNV Moved after StructuredValueConstructor and FunctionAccess
-                         / SchemaDiscriminant           # BNV Moved after StructuredValueConstructor and FunctionAccess
-                         / VariableAccess               # BNV Moved after StructuredValueConstructor
-                         / DiscriminantIdentifier
-    UnsignedConstant    <- UnsignedNumber / CharacterString / NIL / ExtendedNumber
-    SetConstructor      <- "[" _? ( MemberDesignator ( _? "," _? MemberDesignator )* )? _? "]"
-    MemberDesignator    <- Expression ( _? ".." _? Expression )?
+    Expression          <- SimpleExpression ( _ RelationalOperator _ SimpleExpression)?
+    SimpleExpression    <- Sign? _ Term ( _ AddingOperator _ Term )*
+    Term                <- Factor ( _ MultiplyingOperator _ Factor )*
+    Factor              <- Primary ( _ ExponentiatingOperator _ Primary )?
+    Primary             <- VariableAccess
+                         | UnsignedConstant
+                         | SetConstructor
+                         | FunctionAccess
+                         | "(" _ Expression _ ")"
+                         | NOT _ Primary
+                         | ConstantAccess
+                         | SchemaDiscriminant
+                         | StructuredValueConstructor
+                         | DiscriminantIdentifier
+    UnsignedConstant    <- UnsignedNumber | CharacterString | NIL | ExtendedNumber
+    SetConstructor      <- "[" _ ( MemberDesignator ( _ "," _ MemberDesignator )* )? _ "]"
+    MemberDesignator    <- Expression ( _ ".." _ Expression )?
 
 # 6.8.2 (complete)
     ConstantExpression  <- Expression
 
 # 6.8.3.1 (complete)
     ExponentiatingOperator  <- "**" / POW
-    MultiplyingOperator     <- "*" / "/" / DIV / MOD / AND / AND_THEN
-    AddingOperator          <- "+" / "-" / "><" / OR / OR_ELSE
+    MultiplyingOperator     <- "*" / "/" / DIV / MOD / AND_THEN / AND       # BNV Try to match AND_THEN before AND
+    AddingOperator          <- "+" / "-" / "><" / OR_ELSE / OR              # BNV Try to match OR_ELSE before OR
     RelationalOperator      <- "=" / "<>" / "<=" / "<" / ">=" / ">" / IN
 
 # 6.8.3.2 Arithmetic operators TODO?
@@ -309,51 +317,53 @@ EP:
 # 6.8.3.6 String operator TODO
 
 # 6.8.4 (complete)
-    SchemaDiscriminant      <- ( VariableAccess / ConstantAccess ) _? "." _? DiscriminantSpecifier / SchemaDiscriminantIdentifier
+    SchemaDiscriminant      <- ( VariableAccess / ConstantAccess ) _ "." _ DiscriminantSpecifier | SchemaDiscriminantIdentifier
     DiscriminantSpecifier   <- DiscriminantIdentifier
 
 
 # 6.8.5 (complete)
-    FunctionDesignator      <- FunctionName ( _? ActualParameterList )?
-    ActualParameterList     <- "(" _? ActualParameter ( _? "," _? ActualParameter )* _? ")"
+    FunctionDesignator      <- FunctionName ( _ ActualParameterList )?
+    ActualParameterList     <- "(" _ ActualParameter ( _ "," _ ActualParameter )* _ ")"
     ActualParameter         <- Expression / VariableAccess / ProcedureName / FunctionName
 
 # 6.8.6.1 (complete)
-    FunctionAccess          <- EntireFunctionAccess / ComponentFunctionAccess / SubstringFunctionAccess
+    #FunctionAccess          <- EntireFunctionAccess / ComponentFunctionAccess / SubstringFunctionAccess
+# Prospero extension: type viewing.
+    FunctionAccess          <- ( EntireFunctionAccess | ComponentFunctionAccess | SubstringFunctionAccess ) ( _ "::" _ TypeName)?
     ComponentFunctionAccess <- IndexedFunctionAccess / RecordFunctionAccess
     EntireFunctionAccess    <- FunctionDesignator
 
 # 6.8.6.2 (complete)
-    IndexedFunctionAccess   <- ArrayFunction _? "[" _? IndexExpression ( _? "," _? IndexExpression )* _? "]"
+    IndexedFunctionAccess   <- ArrayFunction _ "[" _ IndexExpression ( _ "," _ IndexExpression )* _ "]"
     ArrayFunction           <- FunctionAccess
     StringFunction          <- FunctionAccess
 
 # 6.8.6.3 (complete)
-    RecordFunctionAccess    <- RecordFunction _? "." _? FieldSpecifier
+    RecordFunctionAccess    <- RecordFunction _ "." _ FieldSpecifier
     RecordFunction          <- FunctionAccess
 
 # 6.8.6.4 (complete)
-    FunctionIdentifiedVariable  <- PointerFunction _? "^"
+    FunctionIdentifiedVariable  <- PointerFunction _ "^"
     PointerFunction             <- FunctionAccess
 
 # 6.8.6.5 (complete)
-    SubstringFunctionAccess <- StringFunction _? "[" _? IndexExpression _? ".." _? IndexExpression _? "]"
+    SubstringFunctionAccess <- StringFunction _ "[" _ IndexExpression _ ".." _ IndexExpression _ "]"
 
 # 6.8.7.1 (complete)
-    StructuredValueConstructor  <- ArrayTypeName _? ArrayValue / RecordTypeName _? RecordValue / SetTypeName _? SetValue
-    ComponentValue  <- Expression / ArrayValue / RecordValue
+    StructuredValueConstructor  <- ArrayTypeName _ ArrayValue | RecordTypeName _ RecordValue | SetTypeName _ SetValue
+    ComponentValue  <- Expression | ArrayValue | RecordValue
 
 # 6.8.7.2 (complete)
-    ArrayValue          <- "[" _? ( ArrayValueElement ( _? ";" _? ArrayValueElement )* _? ";"? )? ( _? ArrayValueCompleter _? ";"? )? _? "]"
-    ArrayValueElement   <- CaseConstantList _? ":" _? ComponentValue
-    ArrayValueCompleter <- OTHERWISE _? ComponentValue
+    ArrayValue          <- "[" _ ( ArrayValueElement ( _ ";" _ ArrayValueElement )* _ ";"? )? ( _ ArrayValueCompleter _ ";"? )? _ "]"
+    ArrayValueElement   <- CaseConstantList _ ":" _ ComponentValue
+    ArrayValueCompleter <- OTHERWISE _ ComponentValue
 
 # 6.8.7.3 (complete)
-    RecordValue         <- "[" _? FieldListValue _? "]"
-    FieldListValue      <- ( ( FixedPartValue ( _? ";" _? VariantPartValue )? / VariantPartValue ) _? ";"? )?
-    FixedPartValue      <- FieldValue ( _? ";" _? FieldValue )*
-    FieldValue          <- FieldIdentifier ( _? ";" _? FieldIdentifier )* _? ":" _? ComponentValue
-    VariantPartValue    <- CASE _ ( TagFieldIdentifier _? ":" _?)? ConstantTagValue _? OF _? "[" _? FieldListValue _? "]"
+    RecordValue         <- "[" _ FieldListValue _ "]"
+    FieldListValue      <- ( ( FixedPartValue ( _ ";" _ VariantPartValue )? / VariantPartValue ) _ ";"? )?
+    FixedPartValue      <- FieldValue ( _ ";" _ FieldValue )*
+    FieldValue          <- FieldIdentifier ( _ ";" _ FieldIdentifier )* _ ":" _ ComponentValue
+    VariantPartValue    <- CASE _ ( TagFieldIdentifier _ ":" _)? ConstantTagValue _ OF _ "[" _ FieldListValue _ "]"
     ConstantTagValue    <- ConstantExpression
     TagFieldIdentifier  <- FieldIdentifier
 
@@ -362,50 +372,51 @@ EP:
 
 # 6.8.8.1 (complete)
     ConstantAccess          <- ConstantAccessComponent / ConstantName
-    ConstantAccessComponent <- IndexedConstant / FieldDesignatedConstant / SubstringConstant
+    ConstantAccessComponent <- IndexedConstant | FieldDesignatedConstant | SubstringConstant
 
 # 6.8.8.2 (complete)
-    IndexedConstant <- ArrayConstant _? "[" _? IndexExpression ( _? "," _? IndexExpression )* _? "]" / StringConstant _? "[" _? IndexExpression _? "]"
+    IndexedConstant <- ArrayConstant _ "[" _ IndexExpression ( _ "," _ IndexExpression )* _ "]" | StringConstant _ "[" _ IndexExpression _ "]"
     ArrayConstant   <- ConstantAccess
     StringConstant  <- ConstantAccess
 
 # 6.8.8.3 (complete)
-    FieldDesignatedConstant <- RecordConstant _? "." _? FieldSpecifier / ConstantFieldIdentifier
+    FieldDesignatedConstant <- RecordConstant _ "." _ FieldSpecifier | ConstantFieldIdentifier
     RecordConstant          <- ConstantAccess
 
 # 6.8.8.4 (complete)
-    SubstringConstant   <- StringConstant _? "[" _? IndexExpression _? ".." _? IndexExpression _? "]"
+    SubstringConstant   <- StringConstant _ "[" _ IndexExpression _ ".." _ IndexExpression _ "]"
 
 # 6.9.1 (complete)
-    Statement   <- ( Label _? ":" _? )? ( StructuredStatement / SimpleStatement )   # BNV Moved SimpleStatement last, so StructuredStatement is tried before EmptyStatement.
+#    Statement   <- ( Label _ ":" _ )? ( SimpleStatement | StructuredStatement )
+# Need a longest match on the label because of the Prospero extension that labels can be identifiers. Alternatively, maintain a list of defined labels that are in scope.
+    Statement   <- ( SimpleStatement |  StructuredStatement ) | Label _ ":" _ ( SimpleStatement | StructuredStatement )
 
 # 6.9.2.1 (complete)
-#    SimpleStatement <- EmptyStatement / AssignmentStatement / ProcedureStatement / GotoStatement # Standard
-    SimpleStatement <- AssignmentStatement / ProcedureStatement / GotoStatement / EmptyStatement # BNV Moved EmptyStatement last, try real statements first.
+    SimpleStatement <- EmptyStatement | AssignmentStatement | ProcedureStatement | GotoStatement
     EmptyStatement  <- eps
 
 # 6.9.2.2 (complete)
-    AssignmentStatement <- ( VariableAccess / FunctionIdentifier ) _? ":=" _? Expression
+    AssignmentStatement <- ( VariableAccess / FunctionIdentifier ) _ ":=" _ Expression
 
 # 6.9.2.3 (complete) #BNV Extended for required procedures.
     ProcedureStatement  <-
-                         / READ _? ReadParameterList
-                         / READLN _? ReadlnParameterList
-                         / READSTR _? ReadstrParameterList
-                         / WRITE _? WriteParameterList
-                         / WRITELN _? WritelnParameterList?
-                         / WRITESTR _? WritestrParameterList
-                         / ProcedureName _? ActualParameterList?
+                         / READLN _ ReadlnParameterList
+                         / READSTR _ ReadstrParameterList
+                         / READ _ ReadParameterList
+                         / WRITELN _ WritelnParameterList?
+                         / WRITESTR _ WritestrParameterList
+                         / WRITE _ WriteParameterList
+                         / ProcedureName _ ActualParameterList?
 
 # 6.9.2.4 (complete)
     GotoStatement       <- GOTO _ Label
 
 # 6.9.3.1 (complete)
     StructuredStatement <- CompoundStatement / ConditionalStatement / RepetitiveStatement / WithStatement
-    StatementSequence   <- Statement ( _? ";" _? Statement )*
+    StatementSequence   <- Statement ( _ ";" _ Statement )*
 
 # 6.9.3.2 (complete)
-    CompoundStatement   <- :BEGIN _? StatementSequence _? :END
+    CompoundStatement   <- :BEGIN _ StatementSequence _ :END
 
 # 6.9.3.3 (complete)
     ConditionalStatement    <- IfStatement / CaseStatement
@@ -415,10 +426,10 @@ EP:
     ElsePart    <- ELSE _ Statement
 
 # 6.9.3.5 (complete)
-    CaseStatement           <- "case"i _ CaseIndex _ "of"i _ ( CaseListElement ( _? ";" _? CaseListElement )* ( _? ";"? _? CaseStatementCompleter )? / _? CaseStatementCompleter ) _? ";"? _? END
+    CaseStatement           <- CASE _ CaseIndex _ OF _ ( CaseListElement ( _ ";" _ CaseListElement )* ( _ ";"? _ CaseStatementCompleter )? | _ CaseStatementCompleter ) _ ";"? _ END
     CaseIndex               <- Expression
-    CaseListElement         <- CaseConstantList _? ":" _? Statement
-    CaseStatementCompleter  <- "otherwise"i _ StatementSequence
+    CaseListElement         <- CaseConstantList _ ":" _ Statement
+    CaseStatementCompleter  <- OTHERWISE _ StatementSequence
 
 # 6.9.3.6 (complete)
     RepetitiveStatement <- RepeatStatement / WhileStatement / ForStatement
@@ -430,22 +441,22 @@ EP:
     WhileStatement  <- WHILE _ BooleanExpression _ DO _ Statement
 
 # 6.9.3.9.1 (complete)
-    ForStatement    <- FOR _ ControlVariable _? IterationClause _ DO _ Statement
+    ForStatement    <- FOR _ ControlVariable _ IterationClause _ DO _ Statement
     ControlVariable <- EntireVariable
     IterationClause <- SequenceIteration / SetMemberIteration
 
 # 6.9.3.9.2 (complete)
-    SequenceIteration   <- ":=" _? InitialValue _ ( TO / DOWNTO ) _ FinalValue
+    SequenceIteration   <- ":=" _ InitialValue _ ( TO / DOWNTO ) _ FinalValue
     InitialValue        <- Expression
     FinalValue          <- Expression
 
 # 6.9.3.9.3 (complete)
-    SetMemberIteration  <- "in"i _ SetExpression
+    SetMemberIteration  <- IN _ SetExpression
     SetExpression       <- Expression
 
 # 6.9.3.10 (complete)
     WithStatement                   <- WITH _ WithList _ DO _ Statement
-    WithList                        <- WithElement ( _? "," _? WithElement)*
+    WithList                        <- WithElement ( _ "," _ WithElement)*
     WithElement                     <- VariableAccess / ConstantAccess
     FieldDesignatorIdentifier       <- Identifier
     ConstantFieldIdentifier         <- Identifier
@@ -454,68 +465,68 @@ EP:
 # 6.9.4 Threats
 
 # 6.10.1 (complete)
-    ReadParameterList   <- "(" _? ( FileVariable _? "," _? )? VariableAccess _? ( "," _? VariableAccess _? )* ")"
+    ReadParameterList   <- "(" _ ( FileVariable _ "," _ )? VariableAccess _ ( "," _ VariableAccess _ )* ")"
 
 # 6.10.2 (complete)
-    ReadlnParameterList <- ( "(" _? ( FileVariable / VariableAccess ) _? ( "," _? VariableAccess _? )* ")" )?
+    ReadlnParameterList <- ( "(" _ ( FileVariable / VariableAccess ) _ ( "," _ VariableAccess _ )* ")" )?
 
 # 6.10.3 (complete)
-    WriteParameterList  <- "(" _? ( FileVariable _? "," _? )? WriteParameter _? ( "," _? WriteParameter _? )* ")"
-    WriteParameter      <- Expression ( _? ":" _? Expression ( _? ":" _? Expression )? )?
+    WriteParameterList  <- "(" _ ( FileVariable _ "," _ )? WriteParameter _ ( "," _ WriteParameter _ )* ")"
+    WriteParameter      <- Expression ( _ ":" _ Expression ( _ ":" _ Expression )? )?
 
 # 6.10.4 (complete)
-    WritelnParameterList    <- ( "(" _? ( WriteParameter / FileVariable ) _? ( "," _? WriteParameter _? )* ")" )?   # BNV put WriteParameter before FileVariable.
+    WritelnParameterList    <- ( "(" _ ( FileVariable | WriteParameter ) _ ( "," _ WriteParameter _ )* ")" )?
 
 # 6.11.1 (complete)
-    ModuleDeclaration       <- ModuleHeadeing ( _? ";" _? ModuleBlock )? /
-                               ModuleIdentification _? ";" _? ModuleBlock
-    ModuleHeadeing          <- MODULE Comment? BNVModuleName Comment? InterfaceDirective? Comment? ( "(" ModuleParameterList ")" Comment? )? ";" _? InterfaceSpecificationPart _? ImportPart _? ( ConstantDefinitionPart / TypeDefinitionPart / VariableDeclarationPart / ProcedureAndFunctionHeadingPart)* _? END
+    ModuleDeclaration       <- ModuleHeadeing ( _ ";" _ ModuleBlock )? /
+                               ModuleIdentification _ ";" _ ModuleBlock
+    ModuleHeadeing          <- MODULE Comment? BNVModuleName Comment? InterfaceDirective? Comment? ( "(" ModuleParameterList ")" Comment? )? ";" _ InterfaceSpecificationPart _ ImportPart _ ( ConstantDefinitionPart / TypeDefinitionPart / VariableDeclarationPart / ProcedureAndFunctionHeadingPart)* _ END
     ModuleParameterList     <- IdentifierList
-    ProcedureAndFunctionHeadingPart <- ( ProcedureHeading / FunctionHeading ) _? ";"
+    ProcedureAndFunctionHeadingPart <- ( ProcedureHeading / FunctionHeading ) _ ";"
     ModuleIdentification    <- MODULE Comment? ModuleIdenifier Comment? ImplementationDirective
     ModuleIdenifier         <- Identifier
-    ModuleBlock             <- ImportPart _? ( ConstantDefinitionPart / TypeDefinitionPart / VariableDeclarationPart / ProcedureAndFunctionDeclarationPart )* _? InitializationPart? _? FinalizationPart? _? END
-    InitializationPart      <- TO _ BEGIN _ DO _? Statement _? ";"
-    FinalizationPart        <- TO _ END _ DO _? Statement _? ";"
+    ModuleBlock             <- ImportPart _ ( ConstantDefinitionPart / TypeDefinitionPart / VariableDeclarationPart / ProcedureAndFunctionDeclarationPart )* _ InitializationPart? _ FinalizationPart? _ END
+    InitializationPart      <- TO _ BEGIN _ DO _ Statement _ ";"
+    FinalizationPart        <- TO _ END _ DO _ Statement _ ";"
     BNVModuleName           <- Identifier
 
 # 6.11.2 (complete)
-    InterfaceSpecificationPart  <- EXPORT _? ( ExportPart _? ";" )+
-    ExportPart                  <- Identifier _? "=" _? "(" _? ExportList _? ")"
-    ExportList                  <- ( ExportClause / ExportRange ) ( _? "," _? ( ExportClause / ExportRange ) )*
-    ExportClause                <- ExportableName / ExportRenamingClause
-    ExportRenamingClause        <- ExportableName _? "=>" _? Identifier
+    InterfaceSpecificationPart  <- EXPORT _ ( ExportPart _ ";" )+
+    ExportPart                  <- Identifier _ "=" _ "(" _ ExportList _ ")"
+    ExportList                  <- ( ExportClause | ExportRange ) ( _ "," _ ( ExportClause | ExportRange ) )*
+    ExportClause                <- ExportableName | ExportRenamingClause
+    ExportRenamingClause        <- ExportableName _ "=>" _ Identifier
     ExportableName              <- ConstantName / TypeName / SchemaName / ( ( PROTECTED _ )? VariableName ) / ProcedureName / FunctionName
-    ExportRange                 <- FirstConstantName _? ".." _? LastConstantName
+    ExportRange                 <- FirstConstantName _ ".." _ LastConstantName
     FirstConstantName           <- ConstantName
     LastConstantName            <- ConstantName
     ConstituentIdentifier       <- Identifier
     InterfaceIdentifier         <- Identifier
 
 # 6.11.3 (complete)
-    ImportSpecification         <- InterfaceIdentifier ( _ AccessQualifier )? _? ImportQualifier?
+    ImportSpecification         <- InterfaceIdentifier ( _ AccessQualifier )? _ ImportQualifier?
     AccessQualifier             <- QUALIFIED
-    ImportQualifier             <- ( SelectiveImportOption _? )? "(" _? ImportList _? ")"
+    ImportQualifier             <- ( SelectiveImportOption _ )? "(" _ ImportList _ ")"
     SelectiveImportOption       <- ONLY
-    ImportList                  <- ImportClause _? ("," _? ImportClause _?)*
-    ImportClause                <- ConstituentIdentifier / ImportRenamingClause
-    ImportRenamingClause        <- ConstituentIdentifier _? "=>" _? Identifier
+    ImportList                  <- ImportClause _ ("," _ ImportClause _)*
+    ImportClause                <- ConstituentIdentifier | ImportRenamingClause
+    ImportRenamingClause        <- ConstituentIdentifier _ "=>" _ Identifier
     ImportedInterfaceIdentifier <- Identifier
 
 # 6.11.4 Required interfaces TODO
 
 # 6.12 (complete)
-    MainProgramDeclaration  <- ProgramHeading _? ";" :Spacing? MainProgramBlock # BNV Discarding newlines that have no correspondence in D.
-    ProgramHeading          <- PROGRAM Comment? BNVProgramName ( Comment? "(" _? ProgramParameterList _? ")" )?
+    MainProgramDeclaration  <- ProgramHeading _ ";" :Spacing? MainProgramBlock # BNV Discarding newlines that have no correspondence in D.
+    ProgramHeading          <- PROGRAM Comment? BNVProgramName ( Comment? "(" _ ProgramParameterList _ ")" )?
     ProgramParameterList    <- IdentifierList
-    MainProgramBlock        <- _? Block
+    MainProgramBlock        <- _ Block
     # BNV extensions
     BNVProgramName          <- Identifier
 
 # 6.13
-    Program             <- _? ProgramBlock _?
-    ProgramBlock        <- ( ProgramComponent _? )+
-    ProgramComponent    <- ( MainProgramDeclaration _? "." ) / ( ModuleDeclaration _? "." )
+    Program             <- _ ProgramBlock _
+    ProgramBlock        <- ( ProgramComponent _ )+
+    ProgramComponent    <- ( MainProgramDeclaration _ "." ) / ( ModuleDeclaration _ "." )
 
 # Keywords 6.1.2
     AND         <- "and"i

--- a/pegged/examples/extended_pascal/source/make.d
+++ b/pegged/examples/extended_pascal/source/make.d
@@ -59,7 +59,21 @@ PT failOnWordSymbol(PT)(PT p)
         sicmp(p.matches[0], "VALUE") == 0 ||
         sicmp(p.matches[0], "VAR") == 0 ||
         sicmp(p.matches[0], "WHILE") == 0 ||
-        sicmp(p.matches[0], "WITH") == 0)
+        sicmp(p.matches[0], "WITH") == 0 ||
+    // Prospero extensions:
+        sicmp(p.matches[0], "ABSTRACT") == 0 ||
+        sicmp(p.matches[0], "CLASS") == 0 ||
+        sicmp(p.matches[0], "CONSTRUCTOR") == 0 ||
+        sicmp(p.matches[0], "DESTRUCTOR") == 0 ||
+        sicmp(p.matches[0], "EXCEPT") == 0 ||
+        sicmp(p.matches[0], "IS") == 0 ||
+        sicmp(p.matches[0], "PROPERTY") == 0 ||
+        sicmp(p.matches[0], "REM") == 0 ||
+        sicmp(p.matches[0], "SHL") == 0 ||
+        sicmp(p.matches[0], "SHR") == 0 ||
+        sicmp(p.matches[0], "TRY") == 0 ||
+        sicmp(p.matches[0], "VIEW") == 0 ||
+        sicmp(p.matches[0], "XOR") == 0)
     {
         p.successful = false;
     }


### PR DESCRIPTION
Grammar changes that lead to the successful parse of a 200KiB real-life Prospero Extended Pascal file.

You were asking about performance: The parse takes 13 minutes. The generated HTML file is close to 24 MiB large. I have never traced all of it, because my trace files passed the 1GiB mark and I am short on disk space.

So, it's not fast. To be fair, this grammar is bloated and could probably be optimised heavily for speed. But I like to stay close to the text of the standard, and it is not too slow for my application.

I have been delayed with the documentation that I promised, because it came to me that trying the rules in `longest_match` could possibly be parallelised, and how cool would that be? I almost have it working, but at least on OS X I get a bus error, possibly because of the recursive calls to `longest_match` (I counted 52 levels maximum in my test) and because of the small default stack space for threads on OS X. When I only parallelised the first call to `longest_match` it did work, and 3 minutes quicker, but it doesn't feel right to make a PR for that. And, I didn't take data sharing measures, so each thread is probably using its own memoisation table, which probably wastes a lot of work. So a real solution would involve a lot more I fear, and it is not going to be real fast anyway. But in case we need it, it is in my branch https://github.com/veelo/Pegged/commits/parallel.