### PR TITLE
Left-recursion improvements.

### DIFF
--- a/pegged/grammar.d
+++ b/pegged/grammar.d
@@ -133,7 +133,8 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
             if (!canFind(allLeftRecursiveRules, rule))
                 allLeftRecursiveRules ~= rule;
     foreach (cycle; grammarInfo.leftRecursiveCycles)
-        stoppers ~= cycle[0];
+        if (!stoppers.canFind(cycle[0]))
+            stoppers ~= cycle[0];
 
     // Prints comment showing detected left-recursive cycles.
     string printLeftRecursiveCycles()

--- a/pegged/grammar.d
+++ b/pegged/grammar.d
@@ -177,7 +177,7 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
     //  inserted to test for blocking and if blocked return with "$(D_PARAM code)(p)".
     string maybeBlockedMemo(string name, string code)
     {
-        assert(!stoppers.keys.canFind(name));
+        assert(name !in stoppers);
         foreach (cycle; stoppers)
             foreach (rule; cycle)
                 if (rule == name)
@@ -503,13 +503,12 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
                 string ctfeCode = "        pegged.peg.defined!(" ~ code ~ ", \"" ~ propagatedName ~ "." ~ innerName[1..$-1] ~ "\")";
                 code =            "hooked!(pegged.peg.defined!(" ~ code ~ ", \"" ~ propagatedName ~ "." ~ innerName[1..$-1] ~ "\"), \"" ~ hookedName  ~ "\")";
 
-                import std.algorithm.searching: canFind;
                 if (withMemo == Memoization.no)
                     result ~= "    static TParseTree " ~ shortName ~ "(TParseTree p)\n"
                             ~ "    {\n"
                             ~ "        if(__ctfe)\n"
                             ~ "        {\n"
-                            ~ (stoppers.keys.canFind(shortName) ?
+                            ~ (shortName in stoppers ?
                               "            assert(false, \"" ~ shortName ~ " is left-recursive, which is not supported "
                                                          ~ "at compile-time. Consider using asModule().\");\n"
                               :
@@ -518,7 +517,7 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
                             ~ "        }\n"
                             ~ "        else\n"
                             ~ "        {\n"
-                            ~ (stoppers.keys.canFind(shortName) ?
+                            ~ (shortName in stoppers ?
                               // This rule needs to prevent infinite left-recursion.
                               "            static TParseTree[size_t /*position*/] seed;\n"
                             ~ "            if (auto s = p.end in seed)\n"
@@ -563,7 +562,7 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
                             ~ "    {\n"
                             ~ "        if(__ctfe)\n"
                             ~ "        {\n"
-                            ~ (stoppers.keys.canFind(shortName) ?
+                            ~ (shortName in stoppers ?
                               "            assert(false, \"" ~ shortName ~ " is left-recursive, which is not supported "
                                                          ~ "at compile-time. Consider using asModule().\");\n"
                               :
@@ -572,7 +571,7 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
                             ~ "        }\n"
                             ~ "        else\n"
                             ~ "        {\n"
-                            ~ (stoppers.keys.canFind(shortName) ?
+                            ~ (shortName in stoppers ?
                               // This rule needs to prevent infinite left-recursion.
                               "            static TParseTree[size_t /*position*/] seed;\n"
                             ~ "            if (auto s = p.end in seed)\n"


### PR DESCRIPTION
This brings the parsing of a sample Extended Pascal file down from 13 minutes to 17 seconds. The mistake was not to assign the result of std.algorithm.mutation.remove, which caused an array to grow to a massive size and memoization to never be reenabled. (This is now on row 562.)

It also removes quite a bit of complexity and some requirements that I never really understood why were necessary. Now it appears they aren't.

This is worth a patch-level version bump, I think.