### PR TITLE
Added grammar overload.

### DIFF
--- a/pegged/grammar.d
+++ b/pegged/grammar.d
@@ -106,7 +106,11 @@ string grammar(Memoization withMemo = Memoization.yes)(string definition)
         string result = "static assert(false, `" ~ defAsParseTree.toString("") ~ "`);";
         return result;
     }
-
+    return grammar!(withMemo)(defAsParseTree);
+}
+/// ditto
+string grammar(Memoization withMemo = Memoization.yes)(ParseTree defAsParseTree)
+{
     string[] composedGrammars;
 
     // Grammar analysis in support of left-recursion.


### PR DESCRIPTION
By providing an overload to the grammar function that accepts a parsed "Peg Grammar ParseTree", it allows the grammar to be parsed once and then used in other places outside of just the grammar function.