### PR TITLE
Add a button 'run.dlang.io' button

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Arithmetic:
     Variable <- identifier
 `));
 ```
+[![Open on run.dlang.io](https://img.shields.io/badge/run.dlang.io-open-blue.svg)](https://run.dlang.io/is/AYKe5x)
+
 
 This creates the `Arithmetic` grammar, with the `Expr`, `Add`, `Factor` (and so on) rules for basic arithmetic expressions with operator precedence ('*' and '/' bind stronger than '+' or '-'). `identifier` is a pre-defined parser recognizing your basic C-style identifier (first a letter or underscore, then digits, letters or underscores). In the rest of this document, I'll call 'rule' a `Parser <- Parsing Expression` expression and I'll use 'grammar' to designate the entire group of rules given to `grammar`.
 


### PR DESCRIPTION
I added Pegged to run.dlang.io today. This button allows a reader to quickly open the example on run.dlang.io

For convenience: https://run.dlang.io/is/AYKe5x

I also added Pegged to the DUB mini-series for the DTour: https://tour.dlang.org/tour/en/dub/pegged
Any improvements to that page are welcome too.