### PR TITLE
Fix parenthesis issues blocking documentation generation

### DIFF
--- a/pegged/parser.d
+++ b/pegged/parser.d
@@ -109,7 +109,7 @@ TKNString   <- (&'q{' ('q' NestedList('{',DString,'}')))
 
 DLMString   <- ('q' doublequote) ( (&'{' NestedList('{',DString,'}'))
                                  / (&'[' NestedList('[',DString,']'))
-                                 / (&'(' NestedList('(',DString,')'))
+                                 / (&'$(LPAREN)' NestedList('(',DString,')'))
                                  / (&'<' NestedList('<',DString,'>'))
                                  ) doublequote
 

--- a/pegged/peg.d
+++ b/pegged/peg.d
@@ -244,7 +244,7 @@ struct ParseTree
     string[] matches; /// The matched input's parts. Some expressions match at more than one place, hence matches is an array.
 
     string input; /// The input string that generated the parse tree. Stored here for the parse tree to be passed to other expressions, as input.
-    size_t begin, end; /// Indices for the matched part (from the very beginning of the first match to the last char of the last match.
+    size_t begin, end; /// Indices for the matched part from the very beginning of the first match to the last char of the last match.
 
     ParseTree[] children; /// The sub-trees created by sub-rules parsing.
 

--- a/pegged/tester/testerparser.d
+++ b/pegged/tester/testerparser.d
@@ -31,7 +31,7 @@ Comment <-
 
 NestedComment <- '/+' (!NestedCommentEnd . / NestedComment) NestedCommentEnd
 
-# This is needed to make the /+ +/ nest when the grammar is placed into a D nested comment ;)
+# This is needed to make the /+ +/ nest when the grammar is placed into a D # nested comment ;$(RPAREN)
 NestedCommentEnd <- '+/'
 
 


### PR DESCRIPTION
Building documentation with `dub build -b docs` or `dub build -b ddox` returned an error due to some mismatched parentheses.

Incidentally this error prevents other projects using Pegged as a dependency to build docs properly.

This commit fixes those issues.

EDIT: version informations:

DUB version 1.9.0, built on May  3 2018
DMD64 D Compiler v2.080.0-dirty