### PR TITLE
keep track of the longest failed match to improve error messages

### DIFF
--- a/pegged/peg.d
+++ b/pegged/peg.d
@@ -1656,15 +1656,15 @@ template or(rules...) if (rules.length > 0)
                 failedLength[i] = temp.end;
                 if (temp.end >= longestFail.end)
                 {
+                    if (temp.end == longestFail.end)
+                        errorStringChars += (temp.matches.length > 0 ? temp.matches[$-1].length : 0) + errName.length + 4;
+                    else
+                        errorStringChars = (temp.matches.length > 0 ? temp.matches[$-1].length : 0) + errName.length + 4;
                     maxFailedLength = temp.end;
                     longestFail = temp;
                     names[i] = errName;
                     results[i] = temp;
 
-                    if (temp.end == longestFail.end)
-                        errorStringChars += (temp.matches.length > 0 ? temp.matches[$-1].length : 0) + errName.length + 4;
-                    else
-                        errorStringChars = (temp.matches.length > 0 ? temp.matches[$-1].length : 0) + errName.length + 4;
                 }
                 // Else, this error parsed less input than another one: we discard it.
             }

--- a/pegged/peg.d
+++ b/pegged/peg.d
@@ -1445,6 +1445,62 @@ unittest // 'and' unit test
     , "'abc' 'de' 'f' has two child on 'abc_efghi', the one from 'abc' (success) and the one from 'de' (failure).");
 }
 
+version (unittest) {
+    static ParseTree getError(ref ParseTree p) {
+        if (p.children.length > 0)
+            return getError(p.children[$-1]);
+        return p;
+    }
+}
+
+unittest // 'and' unit test with zeroOrMore and longest failing match
+{
+    alias literal!"abc" A;
+    alias literal!"def" B;
+    alias literal!"ghi" C;
+
+    alias and!(zeroOrMore!(and!(A,B)), C) Thing;
+
+    ParseTree input = ParseTree("",false,[], "abc");
+    ParseTree result = Thing(input);
+
+    assert(!result.successful);
+    assert(getError(result).matches[$-1] == "\"def\"", "and!(zeroOrMore!(and!(literal!\"abc\", literal!\"def\")), literal!\"ghi\") should expected def when input is \"abc\"");
+    assert(result.matches == []);
+}
+
+unittest // 'and' unit test with option and longest failing match
+{
+    alias literal!"abc" A;
+    alias literal!"def" B;
+    alias literal!"ghi" C;
+
+    alias and!(option!(and!(A,B)), C) Thing;
+
+    ParseTree input = ParseTree("",false,[], "abc");
+    ParseTree result = Thing(input);
+
+    assert(!result.successful);
+    assert(getError(result).matches[$-1] == "\"def\"", "and!(option!(and!(literal!\"abc\", literal!\"def\")), literal!\"ghi\") should expected def when input is \"abc\"");
+    assert(result.matches == []);
+}
+
+unittest // 'and' unit test with oneOrMore and longest failing match
+{
+    alias literal!"abc" A;
+    alias literal!"def" B;
+    alias literal!"ghi" C;
+
+    alias and!(oneOrMore!(and!(A,B)), C) Thing;
+
+    ParseTree input = ParseTree("",false,[], "abcdefabc");
+    ParseTree result = Thing(input);
+
+    assert(!result.successful);
+    assert(getError(result).matches[$-1] == "\"def\"", "and!(oneOrMore!(and!(literal!\"abc\", literal!\"def\")), literal!\"ghi\") should expected def when input is \"abcdefabc\"");
+    assert(result.matches == ["abc", "def"]);
+}
+
 template wrapAround(alias before, alias target, alias after)
 {
     ParseTree wrapAround(ParseTree p)


### PR DESCRIPTION
Here I am introducing the `failEnd` and `failedChild` members of the ParseTree.

Currently pegged discards the longest failed match in the option?, the zeroOrMore* or the oneOrMore+ operators.

Let me illustrate:

```
Thing <- (A B)* C
A <- "abc"
B <- "def"
C <- "ghi"
```

Let us run this grammer on the following input: "abc". It will fail of course and the error message will be `expected "ghi" but found end of line`. This is silly because A did actually correctly match (except it is discarded) and the error ought to be `expected "def" but found end of line.`

This also occurs with the (A B)? or the (A B)+ (after the first match).

Essentially the option, zeroOrMore and the oneOrMore rules eat errors, and that can be problematic if during those rules it actually parsed the longest failing match.

There are also more complex causes where some nested rule is correctly parsed, but it could contain a longer failed match, so it is not just about rules that are not successful. E.g.

```
Thing <- AB C
AB <- A B?
A <- "abc"
B <- "def"
C <- "ghi"
```

With input "abc de" it will complain about `expected "ghi" but got "de"`. Of course rule B? is matched longer, and it should complain about that.

This PR introduces additional logic to keep track of the longest failed match.

It is not in a perfect stage (it still needs tests), but I wanted to submit it already to get some feedback.