### PR TITLE
Make makefile support LDC, and use same options

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,8 +1,10 @@
 all:
 	if [ -x /usr/bin/dmd ]; then \
 		dmd -w -wi -O -release -noboundscheck -lib -oflibpegged.a pegged/peg.d pegged/grammar.d pegged/parser.d pegged/introspection.d pegged/dynamic/grammar.d pegged/dynamic/peg.d; \
+	elif [ -x /usr/bin/ldc2 ]; then \
+		ldc2 -w -wi -O2 -release -boundscheck=off -c -of=libpegged.a pegged/peg.d pegged/grammar.d pegged/parser.d pegged/dynamic/grammar.d pegged/dynamic/peg.d; \
 	elif [ -x /usr/bin/gdc ]; then \
-		gdc -c -O -olibpegged.a pegged/peg.d pegged/grammar.d pegged/parser.d pegged/dynamic/grammar.d pegged/dynamic/peg.d; \
+		gdc -Wall -O2 -frelease -fbounds-check=off -c -olibpegged.a pegged/peg.d pegged/grammar.d pegged/parser.d pegged/dynamic/grammar.d pegged/dynamic/peg.d; \
 	fi
 
 clean:


### PR DESCRIPTION
This makes it support ldc, and uses same functional options for all 3 compilers.

Tested on ldc 1.12 (based on dmd 2.082.1), and gdc 8.3.0 (compilation fails with syntax error, because of a feature added in 2.079.1). Options are correct however.