### PR TITLE
Fix defaultFormatFailMsg at compile time

### DIFF
--- a/pegged/peg.d
+++ b/pegged/peg.d
@@ -365,7 +365,7 @@ struct ParseTree
 /**
   * Default fail message formating function
   */
-auto defaultFormatFailMsg = delegate (Position pos, string left, string right, const ParseTree pt)
+immutable defaultFormatFailMsg = delegate (Position pos, string left, string right, const ParseTree pt)
 {
     return "Failure at line " ~ to!string(pos.line) ~ ", col " ~ to!string(pos.col) ~ ", "
         ~ (left.length > 0 ? "after " ~ left.stringified ~ " " : "")


### PR DESCRIPTION
Trying to generate a grammar whose PEG syntax is wrong at compile time with pegged `v0.4.5` and DMD `v2.095.0` or `v2.096.1` fails with:

```
./../pegged/peg.d(284,30): Error: static variable `defaultFormatFailMsg` cannot be read at compile time
../../pegged/peg.d(284,30):        called from here: `this.failMsg(cast(string delegate(Position, string, string, const(ParseTree)))defaultFormatFailMsg, "Sucess")`
../../pegged/peg.d(271,40):        called from here: `this.toStringThisNode(allChildrenSuccessful)`
../../pegged/peg.d(266,60):        called from here: `child.toString(tabs ~ (i < this.children.length - 1LU ? " | " : "   "))`
../../pegged/peg.d(257,12):        13 recursive calls to function `toString`
../../pegged/grammar.d(106,75):        called from here: `defAsParseTree.toString("")`
src/pegged/examples/simple_arithmetic.d(11,14):        called from here: `grammar("\x0aArithmetic:\x0a    Term     < Factor (Add / Sub)*\x0a    Add      <-- \"+\" Factor\x0a    Sub      < \"-\" Factor\x0a    Factor   < Primary (Mul / Div)*\x0a    Mul      < \"*\" Primary\x0a    Div      < \"/\" Primary\x0a    Primary  < Parens / Neg / Number / Variable\x0a    Parens   < :\"(\" Term :\")\"\x0a    Neg      < \"-\" Primary\x0a    Number   < ~([0-9]+)\x0a    Variable <- identifier\x0a
```
- To reproduce, introduce a syntax error, simple as changing a `<` into `<--` (or any symbol not recognized by pegged which is not an `identifier`) in one of the `example/` grammars, such as the `simple_arithmetic` above. Then run `./ci.sh`
- Proposed fix: change `defaultFormatFailMsg` declaration from `auto` to `immutable`. The result is a properly formatted fail msg:
```
/home/fra/_progs/forks/Pegged/examples/simple_arithmetic/src/pegged/examples/simple_arithmetic.d-mixin-11(11,1): Error: static assert:  "Pegged (failure)
 +-Pegged.Grammar (failure)
    +-Pegged.GrammarName[1, 17]["Arithmetic"]
    |  +-Pegged.Identifier[1, 11]["Arithmetic"]
  [full parse tree dump omitted]
```