### PR TITLE
Recognize keyword-starting identifier correctly

### DIFF
--- a/examples/c/src/pegged/examples/c.d
+++ b/examples/c/src/pegged/examples/c.d
@@ -228,9 +228,9 @@ Return <- "return"
 
 # The following comes from me, not an official C grammar
 
-IdentPattern <~ [a-zA-Z_] [a-zA-Z0-9_]*
-
-Identifier <- !(Keyword !IdentPattern) IdentPattern
+IdentifierStart <~ [a-zA-Z_]
+IdentifierCont <~ [a-zA-Z0-9_]+
+Identifier <~ !(Keyword !IdentifierCont) IdentifierStart IdentifierCont?
 
 Keyword <- "auto" / "break" / "case" / "char" / "const" / "continue"
          / "default" / "double" / "do" / "else" / "enum" / "extern"


### PR DESCRIPTION
Identifiers can start with a keyword, e.g. `fortune` starts with `for`. Because `IdentPattern` did not allow for digits, valid identifiers like `auto0` were rejected.
A question not addressed by this is that all identifiers starting with `__` or `_` and uppercase are reserved.