### PR TITLE
add python example

### DIFF
--- a/examples/python/Makefile
+++ b/examples/python/Makefile
@@ -1,0 +1,3 @@
+
+test:
+	dub test

--- a/examples/python/dub.json
+++ b/examples/python/dub.json
@@ -1,0 +1,12 @@
+{
+  "name": "python",
+  "description": "The Python-3 programming language grammar.",
+  "license": "Boost",
+  "targetType": "library",
+  "dependencies": {
+    "pegged":  {
+      "version": "*",
+      "path": "../.."
+    }
+  }
+}

--- a/examples/python/dub.json
+++ b/examples/python/dub.json
@@ -1,7 +1,7 @@
 {
   "name": "python",
   "description": "The Python-3 programming language grammar.",
-  "license": "Boost",
+  "license": "PSF LICENSE",
   "targetType": "library",
   "dependencies": {
     "pegged":  {

--- a/examples/python/src/pegged/examples/python.d
+++ b/examples/python/src/pegged/examples/python.d
@@ -650,8 +650,15 @@ StringPostfix < "c" / "w" / "d"
 ASYNC <- "async"
 
 NAME <~ !Keyword [a-zA-Z_] [a-zA-Z0-9_]*
-Keyword <- "abstract" / "alias" / "align" / "asm" / "assert" / "auto" / "await"
-	/ "body" / "bool" / "break" / "byte"
+# https://docs.python.org/3/reference/lexical_analysis.html#keywords
+Keyword <-
+  / "False"   / "await"    / "else"    / "import"   / "pass"
+  / "None"    / "break"    / "except"  / "in"       / "raise"
+  / "True"    / "class"    / "finally" / "is"       / "return"
+  / "and"     / "continue" / "for"     / "lambda"   / "try"
+  / "as"      / "def"      / "from"    / "nonlocal" / "while"
+  / "assert"  / "del"      / "global"  / "not"      / "with"
+  / "async"   / "elif"     / "if"      / "or"       / "yield"
 
 NUMBER <- IntegerLiteral / FloatLiteral
 

--- a/examples/python/src/pegged/examples/python.d
+++ b/examples/python/src/pegged/examples/python.d
@@ -1,0 +1,640 @@
+module pegged.examples.python;
+
+import pegged.grammar;
+
+// https://docs.python.org/3/reference/grammar.html
+// 3.10.3 Documentation » The Python Language Reference » 10. Full Grammar specification
+enum string pythonGrammar =  `
+Python:
+
+# PEG grammar for Python
+
+
+file: [statements] ENDMARKER
+interactive: statement_newline
+eval: expressions NEWLINE* ENDMARKER
+func_type: '(' [type_expressions] ')' '->' expression NEWLINE* ENDMARKER
+fstring: star_expressions
+
+# type_expressions allow */** but ignore them
+type_expressions:
+    | ','.expression+ ',' '*' expression ',' '**' expression
+    | ','.expression+ ',' '*' expression
+    | ','.expression+ ',' '**' expression
+    | '*' expression ',' '**' expression
+    | '*' expression
+    | '**' expression
+    | ','.expression+
+
+statements: statement+
+statement: compound_stmt  | simple_stmts
+statement_newline:
+    | compound_stmt NEWLINE
+    | simple_stmts
+    | NEWLINE
+    | ENDMARKER
+simple_stmts:
+    | simple_stmt !';' NEWLINE  # Not needed, there for speedup
+    | ';'.simple_stmt+ [';'] NEWLINE
+# NOTE: assignment MUST precede expression, else parsing a simple assignment
+# will throw a SyntaxError.
+simple_stmt:
+    | assignment
+    | star_expressions
+    | return_stmt
+    | import_stmt
+    | raise_stmt
+    | 'pass'
+    | del_stmt
+    | yield_stmt
+    | assert_stmt
+    | 'break'
+    | 'continue'
+    | global_stmt
+    | nonlocal_stmt
+compound_stmt:
+    | function_def
+    | if_stmt
+    | class_def
+    | with_stmt
+    | for_stmt
+    | try_stmt
+    | while_stmt
+    | match_stmt
+
+# NOTE: annotated_rhs may start with 'yield'; yield_expr must start with 'yield'
+assignment:
+    | NAME ':' expression ['=' annotated_rhs ]
+    | ('(' single_target ')'
+         | single_subscript_attribute_target) ':' expression ['=' annotated_rhs ]
+    | (star_targets '=' )+ (yield_expr | star_expressions) !'=' [TYPE_COMMENT]
+    | single_target augassign ~ (yield_expr | star_expressions)
+
+augassign:
+    | '+='
+    | '-='
+    | '*='
+    | '@='
+    | '/='
+    | '%='
+    | '&='
+    | '|='
+    | '^='
+    | '<<='
+    | '>>='
+    | '**='
+    | '//='
+
+global_stmt: 'global' ','.NAME+
+nonlocal_stmt: 'nonlocal' ','.NAME+
+
+yield_stmt: yield_expr
+
+assert_stmt: 'assert' expression [',' expression ]
+
+del_stmt:
+    | 'del' del_targets &(';' | NEWLINE)
+
+import_stmt: import_name | import_from
+import_name: 'import' dotted_as_names
+# note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
+import_from:
+    | 'from' ('.' | '...')* dotted_name 'import' import_from_targets
+    | 'from' ('.' | '...')+ 'import' import_from_targets
+import_from_targets:
+    | '(' import_from_as_names [','] ')'
+    | import_from_as_names !','
+    | '*'
+import_from_as_names:
+    | ','.import_from_as_name+
+import_from_as_name:
+    | NAME ['as' NAME ]
+dotted_as_names:
+    | ','.dotted_as_name+
+dotted_as_name:
+    | dotted_name ['as' NAME ]
+dotted_name:
+    | dotted_name '.' NAME
+    | NAME
+
+if_stmt:
+    | 'if' named_expression ':' block elif_stmt
+    | 'if' named_expression ':' block [else_block]
+elif_stmt:
+    | 'elif' named_expression ':' block elif_stmt
+    | 'elif' named_expression ':' block [else_block]
+else_block:
+    | 'else' ':' block
+
+while_stmt:
+    | 'while' named_expression ':' block [else_block]
+
+for_stmt:
+    | 'for' star_targets 'in' ~ star_expressions ':' [TYPE_COMMENT] block [else_block]
+    | ASYNC 'for' star_targets 'in' ~ star_expressions ':' [TYPE_COMMENT] block [else_block]
+
+with_stmt:
+    | 'with' '(' ','.with_item+ ','? ')' ':' block
+    | 'with' ','.with_item+ ':' [TYPE_COMMENT] block
+    | ASYNC 'with' '(' ','.with_item+ ','? ')' ':' block
+    | ASYNC 'with' ','.with_item+ ':' [TYPE_COMMENT] block
+
+with_item:
+    | expression 'as' star_target &(',' | ')' | ':')
+    | expression
+
+try_stmt:
+    | 'try' ':' block finally_block
+    | 'try' ':' block except_block+ [else_block] [finally_block]
+except_block:
+    | 'except' expression ['as' NAME ] ':' block
+    | 'except' ':' block
+finally_block:
+    | 'finally' ':' block
+
+match_stmt:
+    | "match" subject_expr ':' NEWLINE INDENT case_block+ DEDENT
+subject_expr:
+    | star_named_expression ',' star_named_expressions?
+    | named_expression
+case_block:
+    | "case" patterns guard? ':' block
+guard: 'if' named_expression
+
+patterns:
+    | open_sequence_pattern
+    | pattern
+pattern:
+    | as_pattern
+    | or_pattern
+as_pattern:
+    | or_pattern 'as' pattern_capture_target
+or_pattern:
+    | '|'.closed_pattern+
+closed_pattern:
+    | literal_pattern
+    | capture_pattern
+    | wildcard_pattern
+    | value_pattern
+    | group_pattern
+    | sequence_pattern
+    | mapping_pattern
+    | class_pattern
+
+# Literal patterns are used for equality and identity constraints
+literal_pattern:
+    | signed_number !('+' | '-')
+    | complex_number
+    | strings
+    | 'None'
+    | 'True'
+    | 'False'
+
+# Literal expressions are used to restrict permitted mapping pattern keys
+literal_expr:
+    | signed_number !('+' | '-')
+    | complex_number
+    | strings
+    | 'None'
+    | 'True'
+    | 'False'
+
+complex_number:
+    | signed_real_number '+' imaginary_number
+    | signed_real_number '-' imaginary_number
+
+signed_number:
+    | NUMBER
+    | '-' NUMBER
+
+signed_real_number:
+    | real_number
+    | '-' real_number
+
+real_number:
+    | NUMBER
+
+imaginary_number:
+    | NUMBER
+
+capture_pattern:
+    | pattern_capture_target
+
+pattern_capture_target:
+    | !"_" NAME !('.' | '(' | '=')
+
+wildcard_pattern:
+    | "_"
+
+value_pattern:
+    | attr !('.' | '(' | '=')
+attr:
+    | name_or_attr '.' NAME
+name_or_attr:
+    | attr
+    | NAME
+
+group_pattern:
+    | '(' pattern ')'
+
+sequence_pattern:
+    | '[' maybe_sequence_pattern? ']'
+    | '(' open_sequence_pattern? ')'
+open_sequence_pattern:
+    | maybe_star_pattern ',' maybe_sequence_pattern?
+maybe_sequence_pattern:
+    | ','.maybe_star_pattern+ ','?
+maybe_star_pattern:
+    | star_pattern
+    | pattern
+star_pattern:
+    | '*' pattern_capture_target
+    | '*' wildcard_pattern
+
+mapping_pattern:
+    | '{' '}'
+    | '{' double_star_pattern ','? '}'
+    | '{' items_pattern ',' double_star_pattern ','? '}'
+    | '{' items_pattern ','? '}'
+items_pattern:
+    | ','.key_value_pattern+
+key_value_pattern:
+    | (literal_expr | attr) ':' pattern
+double_star_pattern:
+    | '**' pattern_capture_target
+
+class_pattern:
+    | name_or_attr '(' ')'
+    | name_or_attr '(' positional_patterns ','? ')'
+    | name_or_attr '(' keyword_patterns ','? ')'
+    | name_or_attr '(' positional_patterns ',' keyword_patterns ','? ')'
+positional_patterns:
+    | ','.pattern+
+keyword_patterns:
+    | ','.keyword_pattern+
+keyword_pattern:
+    | NAME '=' pattern
+
+return_stmt:
+    | 'return' [star_expressions]
+
+raise_stmt:
+    | 'raise' expression ['from' expression ]
+    | 'raise'
+
+function_def:
+    | decorators function_def_raw
+    | function_def_raw
+
+function_def_raw:
+    | 'def' NAME '(' [params] ')' ['->' expression ] ':' [func_type_comment] block
+    | ASYNC 'def' NAME '(' [params] ')' ['->' expression ] ':' [func_type_comment] block
+func_type_comment:
+    | NEWLINE TYPE_COMMENT &(NEWLINE INDENT)   # Must be followed by indented block
+    | TYPE_COMMENT
+
+params:
+    | parameters
+
+parameters:
+    | slash_no_default param_no_default* param_with_default* [star_etc]
+    | slash_with_default param_with_default* [star_etc]
+    | param_no_default+ param_with_default* [star_etc]
+    | param_with_default+ [star_etc]
+    | star_etc
+
+# Some duplication here because we can't write (',' | &')'),
+# which is because we don't support empty alternatives (yet).
+#
+slash_no_default:
+    | param_no_default+ '/' ','
+    | param_no_default+ '/' &')'
+slash_with_default:
+    | param_no_default* param_with_default+ '/' ','
+    | param_no_default* param_with_default+ '/' &')'
+
+star_etc:
+    | '*' param_no_default param_maybe_default* [kwds]
+    | '*' ',' param_maybe_default+ [kwds]
+    | kwds
+
+kwds: '**' param_no_default
+
+# One parameter.  This *includes* a following comma and type comment.
+#
+# There are three styles:
+# - No default
+# - With default
+# - Maybe with default
+#
+# There are two alternative forms of each, to deal with type comments:
+# - Ends in a comma followed by an optional type comment
+# - No comma, optional type comment, must be followed by close paren
+# The latter form is for a final parameter without trailing comma.
+#
+param_no_default:
+    | param ',' TYPE_COMMENT?
+    | param TYPE_COMMENT? &')'
+param_with_default:
+    | param default ',' TYPE_COMMENT?
+    | param default TYPE_COMMENT? &')'
+param_maybe_default:
+    | param default? ',' TYPE_COMMENT?
+    | param default? TYPE_COMMENT? &')'
+param: NAME annotation?
+
+annotation: ':' expression
+default: '=' expression
+
+decorators: ('@' named_expression NEWLINE )+
+
+class_def:
+    | decorators class_def_raw
+    | class_def_raw
+class_def_raw:
+    | 'class' NAME ['(' [arguments] ')' ] ':' block
+
+block:
+    | NEWLINE INDENT statements DEDENT
+    | simple_stmts
+
+star_expressions:
+    | star_expression (',' star_expression )+ [',']
+    | star_expression ','
+    | star_expression
+star_expression:
+    | '*' bitwise_or
+    | expression
+
+star_named_expressions: ','.star_named_expression+ [',']
+star_named_expression:
+    | '*' bitwise_or
+    | named_expression
+
+
+assignment_expression:
+    | NAME ':=' ~ expression
+
+named_expression:
+    | assignment_expression
+    | expression !':='
+
+annotated_rhs: yield_expr | star_expressions
+
+expressions:
+    | expression (',' expression )+ [',']
+    | expression ','
+    | expression
+expression:
+    | disjunction 'if' disjunction 'else' expression
+    | disjunction
+    | lambdef
+
+lambdef:
+    | 'lambda' [lambda_params] ':' expression
+
+lambda_params:
+    | lambda_parameters
+
+# lambda_parameters etc. duplicates parameters but without annotations
+# or type comments, and if there's no comma after a parameter, we expect
+# a colon, not a close parenthesis.  (For more, see parameters above.)
+#
+lambda_parameters:
+    | lambda_slash_no_default lambda_param_no_default* lambda_param_with_default* [lambda_star_etc]
+    | lambda_slash_with_default lambda_param_with_default* [lambda_star_etc]
+    | lambda_param_no_default+ lambda_param_with_default* [lambda_star_etc]
+    | lambda_param_with_default+ [lambda_star_etc]
+    | lambda_star_etc
+
+lambda_slash_no_default:
+    | lambda_param_no_default+ '/' ','
+    | lambda_param_no_default+ '/' &':'
+lambda_slash_with_default:
+    | lambda_param_no_default* lambda_param_with_default+ '/' ','
+    | lambda_param_no_default* lambda_param_with_default+ '/' &':'
+
+lambda_star_etc:
+    | '*' lambda_param_no_default lambda_param_maybe_default* [lambda_kwds]
+    | '*' ',' lambda_param_maybe_default+ [lambda_kwds]
+    | lambda_kwds
+
+lambda_kwds: '**' lambda_param_no_default
+
+lambda_param_no_default:
+    | lambda_param ','
+    | lambda_param &':'
+lambda_param_with_default:
+    | lambda_param default ','
+    | lambda_param default &':'
+lambda_param_maybe_default:
+    | lambda_param default? ','
+    | lambda_param default? &':'
+lambda_param: NAME
+
+disjunction:
+    | conjunction ('or' conjunction )+
+    | conjunction
+conjunction:
+    | inversion ('and' inversion )+
+    | inversion
+inversion:
+    | 'not' inversion
+    | comparison
+comparison:
+    | bitwise_or compare_op_bitwise_or_pair+
+    | bitwise_or
+compare_op_bitwise_or_pair:
+    | eq_bitwise_or
+    | noteq_bitwise_or
+    | lte_bitwise_or
+    | lt_bitwise_or
+    | gte_bitwise_or
+    | gt_bitwise_or
+    | notin_bitwise_or
+    | in_bitwise_or
+    | isnot_bitwise_or
+    | is_bitwise_or
+eq_bitwise_or: '==' bitwise_or
+noteq_bitwise_or:
+    | ('!=' ) bitwise_or
+lte_bitwise_or: '<=' bitwise_or
+lt_bitwise_or: '<' bitwise_or
+gte_bitwise_or: '>=' bitwise_or
+gt_bitwise_or: '>' bitwise_or
+notin_bitwise_or: 'not' 'in' bitwise_or
+in_bitwise_or: 'in' bitwise_or
+isnot_bitwise_or: 'is' 'not' bitwise_or
+is_bitwise_or: 'is' bitwise_or
+
+bitwise_or:
+    | bitwise_or '|' bitwise_xor
+    | bitwise_xor
+bitwise_xor:
+    | bitwise_xor '^' bitwise_and
+    | bitwise_and
+bitwise_and:
+    | bitwise_and '&' shift_expr
+    | shift_expr
+shift_expr:
+    | shift_expr '<<' sum
+    | shift_expr '>>' sum
+    | sum
+
+sum:
+    | sum '+' term
+    | sum '-' term
+    | term
+term:
+    | term '*' factor
+    | term '/' factor
+    | term '//' factor
+    | term '%' factor
+    | term '@' factor
+    | factor
+factor:
+    | '+' factor
+    | '-' factor
+    | '~' factor
+    | power
+power:
+    | await_primary '**' factor
+    | await_primary
+await_primary:
+    | AWAIT primary
+    | primary
+primary:
+    | primary '.' NAME
+    | primary genexp
+    | primary '(' [arguments] ')'
+    | primary '[' slices ']'
+    | atom
+
+slices:
+    | slice !','
+    | ','.slice+ [',']
+slice:
+    | [expression] ':' [expression] [':' [expression] ]
+    | named_expression
+atom:
+    | NAME
+    | 'True'
+    | 'False'
+    | 'None'
+    | strings
+    | NUMBER
+    | (tuple | group | genexp)
+    | (list | listcomp)
+    | (dict | set | dictcomp | setcomp)
+    | '...'
+
+strings: STRING+
+list:
+    | '[' [star_named_expressions] ']'
+listcomp:
+    | '[' named_expression for_if_clauses ']'
+tuple:
+    | '(' [star_named_expression ',' [star_named_expressions]  ] ')'
+group:
+    | '(' (yield_expr | named_expression) ')'
+genexp:
+    | '(' ( assignment_expression | expression !':=') for_if_clauses ')'
+set: '{' star_named_expressions '}'
+setcomp:
+    | '{' named_expression for_if_clauses '}'
+dict:
+    | '{' [double_starred_kvpairs] '}'
+
+dictcomp:
+    | '{' kvpair for_if_clauses '}'
+double_starred_kvpairs: ','.double_starred_kvpair+ [',']
+double_starred_kvpair:
+    | '**' bitwise_or
+    | kvpair
+kvpair: expression ':' expression
+for_if_clauses:
+    | for_if_clause+
+for_if_clause:
+    | ASYNC 'for' star_targets 'in' ~ disjunction ('if' disjunction )*
+    | 'for' star_targets 'in' ~ disjunction ('if' disjunction )*
+
+yield_expr:
+    | 'yield' 'from' expression
+    | 'yield' [star_expressions]
+
+arguments:
+    | args [','] &')'
+args:
+    | ','.(starred_expression | ( assignment_expression | expression !':=') !'=')+ [',' kwargs ]
+    | kwargs
+
+kwargs:
+    | ','.kwarg_or_starred+ ',' ','.kwarg_or_double_starred+
+    | ','.kwarg_or_starred+
+    | ','.kwarg_or_double_starred+
+starred_expression:
+    | '*' expression
+kwarg_or_starred:
+    | NAME '=' expression
+    | starred_expression
+kwarg_or_double_starred:
+    | NAME '=' expression
+    | '**' expression
+
+# NOTE: star_targets may contain *bitwise_or, targets may not.
+star_targets:
+    | star_target !','
+    | star_target (',' star_target )* [',']
+star_targets_list_seq: ','.star_target+ [',']
+star_targets_tuple_seq:
+    | star_target (',' star_target )+ [',']
+    | star_target ','
+star_target:
+    | '*' (!'*' star_target)
+    | target_with_star_atom
+target_with_star_atom:
+    | t_primary '.' NAME !t_lookahead
+    | t_primary '[' slices ']' !t_lookahead
+    | star_atom
+star_atom:
+    | NAME
+    | '(' target_with_star_atom ')'
+    | '(' [star_targets_tuple_seq] ')'
+    | '[' [star_targets_list_seq] ']'
+
+single_target:
+    | single_subscript_attribute_target
+    | NAME
+    | '(' single_target ')'
+single_subscript_attribute_target:
+    | t_primary '.' NAME !t_lookahead
+    | t_primary '[' slices ']' !t_lookahead
+
+del_targets: ','.del_target+ [',']
+del_target:
+    | t_primary '.' NAME !t_lookahead
+    | t_primary '[' slices ']' !t_lookahead
+    | del_t_atom
+del_t_atom:
+    | NAME
+    | '(' del_target ')'
+    | '(' [del_targets] ')'
+    | '[' [del_targets] ']'
+
+t_primary:
+    | t_primary '.' NAME &t_lookahead
+    | t_primary '[' slices ']' &t_lookahead
+    | t_primary genexp &t_lookahead
+    | t_primary '(' [arguments] ')' &t_lookahead
+    | atom &t_lookahead
+t_lookahead: '(' | '[' | '.'
+`;
+
+
+mixin(grammar(pythonGrammar));
+
+unittest
+{
+    import std.stdio;
+    writeln(Python(`m = "Hello";`));
+}

--- a/examples/python/src/pegged/examples/python.d
+++ b/examples/python/src/pegged/examples/python.d
@@ -675,6 +675,8 @@ HexDigit < [0-9a-fA-F]
 FloatLiteral <- Sign? Integer "." Integer? (("e" / "E") Sign? Integer)?
 
 Sign <- ("-" / "+")?
+
+INDENT <- "\t" / " "
 `;
 
 

--- a/examples/python/src/pegged/examples/python.d
+++ b/examples/python/src/pegged/examples/python.d
@@ -659,6 +659,7 @@ Keyword <-
   / "as"      / "def"      / "from"    / "nonlocal" / "while"
   / "assert"  / "del"      / "global"  / "not"      / "with"
   / "async"   / "elif"     / "if"      / "or"       / "yield"
+  / "type"
 
 NUMBER <- IntegerLiteral / FloatLiteral
 
@@ -686,6 +687,8 @@ Sign <- ("-" / "+")?
 INDENT <- "\t" / " "
 DEDENT <- endOfLine
 NEWLINE <- endOfLine
+
+TYPE_COMMENT <- "#" "type" ":"
 `;
 
 

--- a/examples/python/src/pegged/examples/python.d
+++ b/examples/python/src/pegged/examples/python.d
@@ -10,49 +10,49 @@ Python:
 # PEG grammar for Python
 
 
-file: [statements] ENDMARKER
-interactive: statement_newline
-eval: expressions NEWLINE* ENDMARKER
-func_type: '(' [type_expressions] ')' '->' expression NEWLINE* ENDMARKER
-fstring: star_expressions
+file <-  [statements] # ENDMARKER
+interactive <-  statement_newline
+eval <-  expressions NEWLINE* # ENDMARKER
+func_type <-  "(" [type_expressions] ")" "->" expression NEWLINE* # ENDMARKER
+fstring <-  star_expressions
 
 # type_expressions allow */** but ignore them
-type_expressions:
-    | ','.expression+ ',' '*' expression ',' '**' expression
-    | ','.expression+ ',' '*' expression
-    | ','.expression+ ',' '**' expression
-    | '*' expression ',' '**' expression
-    | '*' expression
-    | '**' expression
-    | ','.expression+
+type_expressions <- 
+    | ",".expression+ "," "*" expression "," "**" expression
+    | ",".expression+ "," "*" expression
+    | ",".expression+ "," "**" expression
+    | "*" expression "," "**" expression
+    | "*" expression
+    | "**" expression
+    | ",".expression+
 
-statements: statement+
-statement: compound_stmt  | simple_stmts
-statement_newline:
+statements <-  statement+
+statement <-  compound_stmt  | simple_stmts
+statement_newline <- 
     | compound_stmt NEWLINE
     | simple_stmts
     | NEWLINE
-    | ENDMARKER
-simple_stmts:
-    | simple_stmt !';' NEWLINE  # Not needed, there for speedup
-    | ';'.simple_stmt+ [';'] NEWLINE
-# NOTE: assignment MUST precede expression, else parsing a simple assignment
+#   | ENDMARKER
+simple_stmts <- 
+    | simple_stmt !";" NEWLINE  # Not needed, there for speedup
+    | ";".simple_stmt+ [";"] NEWLINE
+# NOTE <-  assignment MUST precede expression, else parsing a simple assignment
 # will throw a SyntaxError.
-simple_stmt:
+simple_stmt <- 
     | assignment
     | star_expressions
     | return_stmt
     | import_stmt
     | raise_stmt
-    | 'pass'
+    | "pass"
     | del_stmt
     | yield_stmt
     | assert_stmt
-    | 'break'
-    | 'continue'
+    | "break"
+    | "continue"
     | global_stmt
     | nonlocal_stmt
-compound_stmt:
+compound_stmt <- 
     | function_def
     | if_stmt
     | class_def
@@ -62,116 +62,116 @@ compound_stmt:
     | while_stmt
     | match_stmt
 
-# NOTE: annotated_rhs may start with 'yield'; yield_expr must start with 'yield'
-assignment:
-    | NAME ':' expression ['=' annotated_rhs ]
-    | ('(' single_target ')'
-         | single_subscript_attribute_target) ':' expression ['=' annotated_rhs ]
-    | (star_targets '=' )+ (yield_expr | star_expressions) !'=' [TYPE_COMMENT]
+# NOTE: annotated_rhs may start with "yield"; yield_expr must start with "yield"
+assignment <- 
+    | NAME ":" expression ["=" annotated_rhs ]
+    | ("(" single_target ")"
+         | single_subscript_attribute_target) ":" expression ["=" annotated_rhs ]
+    | (star_targets "=" )+ (yield_expr | star_expressions) !"=" [TYPE_COMMENT]
     | single_target augassign ~ (yield_expr | star_expressions)
 
-augassign:
-    | '+='
-    | '-='
-    | '*='
-    | '@='
-    | '/='
-    | '%='
-    | '&='
-    | '|='
-    | '^='
-    | '<<='
-    | '>>='
-    | '**='
-    | '//='
+augassign <- 
+    | "+="
+    | "-="
+    | "*="
+    | "@="
+    | "/="
+    | "%="
+    | "&="
+    | "|="
+    | "^="
+    | "<<="
+    | ">>="
+    | "**="
+    | "//="
 
-global_stmt: 'global' ','.NAME+
-nonlocal_stmt: 'nonlocal' ','.NAME+
+global_stmt <-  "global" ",".NAME+
+nonlocal_stmt <-  "nonlocal" ",".NAME+
 
-yield_stmt: yield_expr
+yield_stmt <-  yield_expr
 
-assert_stmt: 'assert' expression [',' expression ]
+assert_stmt <-  "assert" expression ["," expression ]
 
-del_stmt:
-    | 'del' del_targets &(';' | NEWLINE)
+del_stmt <- 
+    | "del" del_targets &(";" | NEWLINE)
 
-import_stmt: import_name | import_from
-import_name: 'import' dotted_as_names
-# note below: the ('.' | '...') is necessary because '...' is tokenized as ELLIPSIS
-import_from:
-    | 'from' ('.' | '...')* dotted_name 'import' import_from_targets
-    | 'from' ('.' | '...')+ 'import' import_from_targets
-import_from_targets:
-    | '(' import_from_as_names [','] ')'
-    | import_from_as_names !','
-    | '*'
-import_from_as_names:
-    | ','.import_from_as_name+
-import_from_as_name:
-    | NAME ['as' NAME ]
-dotted_as_names:
-    | ','.dotted_as_name+
-dotted_as_name:
-    | dotted_name ['as' NAME ]
-dotted_name:
-    | dotted_name '.' NAME
+import_stmt <-  import_name | import_from
+import_name <-  "import" dotted_as_names
+# note below <-  the ("." | "...") is necessary because "..." is tokenized as ELLIPSIS
+import_from <- 
+    | "from" ("." | "...")* dotted_name "import" import_from_targets
+    | "from" ("." | "...")+ "import" import_from_targets
+import_from_targets <- 
+    | "(" import_from_as_names [","] ")"
+    | import_from_as_names !","
+    | "*"
+import_from_as_names <- 
+    | ",".import_from_as_name+
+import_from_as_name <- 
+    | NAME ["as" NAME ]
+dotted_as_names <- 
+    | ",".dotted_as_name+
+dotted_as_name <- 
+    | dotted_name ["as" NAME ]
+dotted_name <- 
+    | dotted_name "." NAME
     | NAME
 
-if_stmt:
-    | 'if' named_expression ':' block elif_stmt
-    | 'if' named_expression ':' block [else_block]
-elif_stmt:
-    | 'elif' named_expression ':' block elif_stmt
-    | 'elif' named_expression ':' block [else_block]
-else_block:
-    | 'else' ':' block
+if_stmt <- 
+    | "if" named_expression ":" block elif_stmt
+    | "if" named_expression ":" block [else_block]
+elif_stmt <- 
+    | "elif" named_expression ":" block elif_stmt
+    | "elif" named_expression ":" block [else_block]
+else_block <- 
+    | "else" ":" block
 
-while_stmt:
-    | 'while' named_expression ':' block [else_block]
+while_stmt <- 
+    | "while" named_expression ":" block [else_block]
 
-for_stmt:
-    | 'for' star_targets 'in' ~ star_expressions ':' [TYPE_COMMENT] block [else_block]
-    | ASYNC 'for' star_targets 'in' ~ star_expressions ':' [TYPE_COMMENT] block [else_block]
+for_stmt <- 
+    | "for" star_targets "in" ~ star_expressions ":" [TYPE_COMMENT] block [else_block]
+    | ASYNC "for" star_targets "in" ~ star_expressions ":" [TYPE_COMMENT] block [else_block]
 
-with_stmt:
-    | 'with' '(' ','.with_item+ ','? ')' ':' block
-    | 'with' ','.with_item+ ':' [TYPE_COMMENT] block
-    | ASYNC 'with' '(' ','.with_item+ ','? ')' ':' block
-    | ASYNC 'with' ','.with_item+ ':' [TYPE_COMMENT] block
+with_stmt <- 
+    | "with" "(" ",".with_item+ ","? ")" ":" block
+    | "with" ",".with_item+ ":" [TYPE_COMMENT] block
+    | ASYNC "with" "(" ",".with_item+ ","? ")" ":" block
+    | ASYNC "with" ",".with_item+ ":" [TYPE_COMMENT] block
 
-with_item:
-    | expression 'as' star_target &(',' | ')' | ':')
+with_item <- 
+    | expression "as" star_target &("," | ")" | ":")
     | expression
 
-try_stmt:
-    | 'try' ':' block finally_block
-    | 'try' ':' block except_block+ [else_block] [finally_block]
-except_block:
-    | 'except' expression ['as' NAME ] ':' block
-    | 'except' ':' block
-finally_block:
-    | 'finally' ':' block
+try_stmt <- 
+    | "try" ":" block finally_block
+    | "try" ":" block except_block+ [else_block] [finally_block]
+except_block <- 
+    | "except" expression ["as" NAME ] ":" block
+    | "except" ":" block
+finally_block <- 
+    | "finally" ":" block
 
-match_stmt:
-    | "match" subject_expr ':' NEWLINE INDENT case_block+ DEDENT
-subject_expr:
-    | star_named_expression ',' star_named_expressions?
+match_stmt <- 
+    | "match" subject_expr ":" NEWLINE INDENT case_block+ DEDENT
+subject_expr <- 
+    | star_named_expression "," star_named_expressions?
     | named_expression
-case_block:
-    | "case" patterns guard? ':' block
-guard: 'if' named_expression
+case_block <- 
+    | "case" patterns guard? ":" block
+guard <-  "if" named_expression
 
-patterns:
+patterns <- 
     | open_sequence_pattern
     | pattern
-pattern:
+pattern <- 
     | as_pattern
     | or_pattern
-as_pattern:
-    | or_pattern 'as' pattern_capture_target
-or_pattern:
-    | '|'.closed_pattern+
-closed_pattern:
+as_pattern <- 
+    | or_pattern "as" pattern_capture_target
+or_pattern <- 
+    | "|".closed_pattern+
+closed_pattern <- 
     | literal_pattern
     | capture_pattern
     | wildcard_pattern
@@ -182,143 +182,143 @@ closed_pattern:
     | class_pattern
 
 # Literal patterns are used for equality and identity constraints
-literal_pattern:
-    | signed_number !('+' | '-')
+literal_pattern <- 
+    | signed_number !("+" | "-")
     | complex_number
     | strings
-    | 'None'
-    | 'True'
-    | 'False'
+    | "None"
+    | "True"
+    | "False"
 
 # Literal expressions are used to restrict permitted mapping pattern keys
-literal_expr:
-    | signed_number !('+' | '-')
+literal_expr <- 
+    | signed_number !("+" | "-")
     | complex_number
     | strings
-    | 'None'
-    | 'True'
-    | 'False'
+    | "None"
+    | "True"
+    | "False"
 
-complex_number:
-    | signed_real_number '+' imaginary_number
-    | signed_real_number '-' imaginary_number
+complex_number <- 
+    | signed_real_number "+" imaginary_number
+    | signed_real_number "-" imaginary_number
 
-signed_number:
+signed_number <- 
     | NUMBER
-    | '-' NUMBER
+    | "-" NUMBER
 
-signed_real_number:
+signed_real_number <- 
     | real_number
-    | '-' real_number
+    | "-" real_number
 
-real_number:
+real_number <- 
     | NUMBER
 
-imaginary_number:
+imaginary_number <- 
     | NUMBER
 
-capture_pattern:
+capture_pattern <- 
     | pattern_capture_target
 
-pattern_capture_target:
-    | !"_" NAME !('.' | '(' | '=')
+pattern_capture_target <- 
+    | !"_" NAME !("." | "(" | "=")
 
-wildcard_pattern:
+wildcard_pattern <- 
     | "_"
 
-value_pattern:
-    | attr !('.' | '(' | '=')
-attr:
-    | name_or_attr '.' NAME
-name_or_attr:
+value_pattern <- 
+    | attr !("." | "(" | "=")
+attr <- 
+    | name_or_attr "." NAME
+name_or_attr <- 
     | attr
     | NAME
 
-group_pattern:
-    | '(' pattern ')'
+group_pattern <- 
+    | "(" pattern ")"
 
-sequence_pattern:
-    | '[' maybe_sequence_pattern? ']'
-    | '(' open_sequence_pattern? ')'
-open_sequence_pattern:
-    | maybe_star_pattern ',' maybe_sequence_pattern?
-maybe_sequence_pattern:
-    | ','.maybe_star_pattern+ ','?
-maybe_star_pattern:
+sequence_pattern <- 
+    | "[" maybe_sequence_pattern? "]"
+    | "(" open_sequence_pattern? ")"
+open_sequence_pattern <- 
+    | maybe_star_pattern "," maybe_sequence_pattern?
+maybe_sequence_pattern <- 
+    | ",".maybe_star_pattern+ ","?
+maybe_star_pattern <- 
     | star_pattern
     | pattern
-star_pattern:
-    | '*' pattern_capture_target
-    | '*' wildcard_pattern
+star_pattern <- 
+    | "*" pattern_capture_target
+    | "*" wildcard_pattern
 
-mapping_pattern:
-    | '{' '}'
-    | '{' double_star_pattern ','? '}'
-    | '{' items_pattern ',' double_star_pattern ','? '}'
-    | '{' items_pattern ','? '}'
-items_pattern:
-    | ','.key_value_pattern+
-key_value_pattern:
-    | (literal_expr | attr) ':' pattern
-double_star_pattern:
-    | '**' pattern_capture_target
+mapping_pattern <- 
+    | "{" "}"
+    | "{" double_star_pattern ","? "}"
+    | "{" items_pattern "," double_star_pattern ","? "}"
+    | "{" items_pattern ","? "}"
+items_pattern <- 
+    | ",".key_value_pattern+
+key_value_pattern <- 
+    | (literal_expr | attr) ":" pattern
+double_star_pattern <- 
+    | "**" pattern_capture_target
 
-class_pattern:
-    | name_or_attr '(' ')'
-    | name_or_attr '(' positional_patterns ','? ')'
-    | name_or_attr '(' keyword_patterns ','? ')'
-    | name_or_attr '(' positional_patterns ',' keyword_patterns ','? ')'
-positional_patterns:
-    | ','.pattern+
-keyword_patterns:
-    | ','.keyword_pattern+
-keyword_pattern:
-    | NAME '=' pattern
+class_pattern <- 
+    | name_or_attr "(" ")"
+    | name_or_attr "(" positional_patterns ","? ")"
+    | name_or_attr "(" keyword_patterns ","? ")"
+    | name_or_attr "(" positional_patterns "," keyword_patterns ","? ")"
+positional_patterns <- 
+    | ",".pattern+
+keyword_patterns <- 
+    | ",".keyword_pattern+
+keyword_pattern <- 
+    | NAME "=" pattern
 
-return_stmt:
-    | 'return' [star_expressions]
+return_stmt <- 
+    | "return" [star_expressions]
 
-raise_stmt:
-    | 'raise' expression ['from' expression ]
-    | 'raise'
+raise_stmt <- 
+    | "raise" expression ["from" expression ]
+    | "raise"
 
-function_def:
+function_def <- 
     | decorators function_def_raw
     | function_def_raw
 
-function_def_raw:
-    | 'def' NAME '(' [params] ')' ['->' expression ] ':' [func_type_comment] block
-    | ASYNC 'def' NAME '(' [params] ')' ['->' expression ] ':' [func_type_comment] block
-func_type_comment:
+function_def_raw <- 
+    | "def" NAME "(" [params] ")" ["->" expression ] ":" [func_type_comment] block
+    | ASYNC "def" NAME "(" [params] ")" ["->" expression ] ":" [func_type_comment] block
+func_type_comment <- 
     | NEWLINE TYPE_COMMENT &(NEWLINE INDENT)   # Must be followed by indented block
     | TYPE_COMMENT
 
-params:
+params <- 
     | parameters
 
-parameters:
+parameters <- 
     | slash_no_default param_no_default* param_with_default* [star_etc]
     | slash_with_default param_with_default* [star_etc]
     | param_no_default+ param_with_default* [star_etc]
     | param_with_default+ [star_etc]
     | star_etc
 
-# Some duplication here because we can't write (',' | &')'),
+# Some duplication here because we can't write ("," | &")"),
 # which is because we don't support empty alternatives (yet).
 #
-slash_no_default:
-    | param_no_default+ '/' ','
-    | param_no_default+ '/' &')'
-slash_with_default:
-    | param_no_default* param_with_default+ '/' ','
-    | param_no_default* param_with_default+ '/' &')'
+slash_no_default <- 
+    | param_no_default+ "/" ","
+    | param_no_default+ "/" &")"
+slash_with_default <- 
+    | param_no_default* param_with_default+ "/" ","
+    | param_no_default* param_with_default+ "/" &")"
 
-star_etc:
-    | '*' param_no_default param_maybe_default* [kwds]
-    | '*' ',' param_maybe_default+ [kwds]
+star_etc <- 
+    | "*" param_no_default param_maybe_default* [kwds]
+    | "*" "," param_maybe_default+ [kwds]
     | kwds
 
-kwds: '**' param_no_default
+kwds <-  "**" param_no_default
 
 # One parameter.  This *includes* a following comma and type comment.
 #
@@ -332,119 +332,120 @@ kwds: '**' param_no_default
 # - No comma, optional type comment, must be followed by close paren
 # The latter form is for a final parameter without trailing comma.
 #
-param_no_default:
-    | param ',' TYPE_COMMENT?
-    | param TYPE_COMMENT? &')'
-param_with_default:
-    | param default ',' TYPE_COMMENT?
-    | param default TYPE_COMMENT? &')'
-param_maybe_default:
-    | param default? ',' TYPE_COMMENT?
-    | param default? TYPE_COMMENT? &')'
-param: NAME annotation?
+param_no_default <- 
+    | param "," TYPE_COMMENT?
+    | param TYPE_COMMENT? &")"
+param_with_default <- 
+    | param default_expr "," TYPE_COMMENT?
+    | param default_expr TYPE_COMMENT? &")"
+param_maybe_default <- 
+    | param default_expr? "," TYPE_COMMENT?
+    | param default_expr? TYPE_COMMENT? &")"
+param <-  NAME annotation?
 
-annotation: ':' expression
-default: '=' expression
+annotation <-  ":" expression
+default_expr <-  "=" expression
 
-decorators: ('@' named_expression NEWLINE )+
+decorators <-  ("@" named_expression NEWLINE )+
 
-class_def:
+class_def <- 
     | decorators class_def_raw
     | class_def_raw
-class_def_raw:
-    | 'class' NAME ['(' [arguments] ')' ] ':' block
 
-block:
+class_def_raw <-
+    | "class" NAME ("(" arguments? ")")? ":" block
+
+block <- 
     | NEWLINE INDENT statements DEDENT
     | simple_stmts
 
-star_expressions:
-    | star_expression (',' star_expression )+ [',']
-    | star_expression ','
+star_expressions <- 
+    | star_expression ("," star_expression )+ [","]
+    | star_expression ","
     | star_expression
-star_expression:
-    | '*' bitwise_or
+star_expression <- 
+    | "*" bitwise_or
     | expression
 
-star_named_expressions: ','.star_named_expression+ [',']
-star_named_expression:
-    | '*' bitwise_or
+star_named_expressions <-  ",".star_named_expression+ [","]
+star_named_expression <- 
+    | "*" bitwise_or
     | named_expression
 
 
-assignment_expression:
-    | NAME ':=' ~ expression
+assignment_expression <- 
+    | NAME ":=" ~ expression
 
-named_expression:
+named_expression <- 
     | assignment_expression
-    | expression !':='
+    | expression !":="
 
-annotated_rhs: yield_expr | star_expressions
+annotated_rhs <-  yield_expr | star_expressions
 
-expressions:
-    | expression (',' expression )+ [',']
-    | expression ','
+expressions <- 
+    | expression ("," expression )+ [","]
+    | expression ","
     | expression
-expression:
-    | disjunction 'if' disjunction 'else' expression
+expression <- 
+    | disjunction "if" disjunction "else" expression
     | disjunction
     | lambdef
 
-lambdef:
-    | 'lambda' [lambda_params] ':' expression
+lambdef <- 
+    | "lambda" [lambda_params] ":" expression
 
-lambda_params:
+lambda_params <- 
     | lambda_parameters
 
 # lambda_parameters etc. duplicates parameters but without annotations
 # or type comments, and if there's no comma after a parameter, we expect
 # a colon, not a close parenthesis.  (For more, see parameters above.)
 #
-lambda_parameters:
+lambda_parameters <- 
     | lambda_slash_no_default lambda_param_no_default* lambda_param_with_default* [lambda_star_etc]
     | lambda_slash_with_default lambda_param_with_default* [lambda_star_etc]
     | lambda_param_no_default+ lambda_param_with_default* [lambda_star_etc]
     | lambda_param_with_default+ [lambda_star_etc]
     | lambda_star_etc
 
-lambda_slash_no_default:
-    | lambda_param_no_default+ '/' ','
-    | lambda_param_no_default+ '/' &':'
-lambda_slash_with_default:
-    | lambda_param_no_default* lambda_param_with_default+ '/' ','
-    | lambda_param_no_default* lambda_param_with_default+ '/' &':'
+lambda_slash_no_default <- 
+    | lambda_param_no_default+ "/" ","
+    | lambda_param_no_default+ "/" &":"
+lambda_slash_with_default <- 
+    | lambda_param_no_default* lambda_param_with_default+ "/" ","
+    | lambda_param_no_default* lambda_param_with_default+ "/" &":"
 
-lambda_star_etc:
-    | '*' lambda_param_no_default lambda_param_maybe_default* [lambda_kwds]
-    | '*' ',' lambda_param_maybe_default+ [lambda_kwds]
+lambda_star_etc <- 
+    | "*" lambda_param_no_default lambda_param_maybe_default* [lambda_kwds]
+    | "*" "," lambda_param_maybe_default+ [lambda_kwds]
     | lambda_kwds
 
-lambda_kwds: '**' lambda_param_no_default
+lambda_kwds <-  "**" lambda_param_no_default
 
-lambda_param_no_default:
-    | lambda_param ','
-    | lambda_param &':'
-lambda_param_with_default:
-    | lambda_param default ','
-    | lambda_param default &':'
-lambda_param_maybe_default:
-    | lambda_param default? ','
-    | lambda_param default? &':'
-lambda_param: NAME
+lambda_param_no_default <- 
+    | lambda_param ","
+    | lambda_param &":"
+lambda_param_with_default <- 
+    | lambda_param default_expr ","
+    | lambda_param default_expr &":"
+lambda_param_maybe_default <- 
+    | lambda_param default_expr? ","
+    | lambda_param default_expr? &":"
+lambda_param <-  NAME
 
-disjunction:
-    | conjunction ('or' conjunction )+
+disjunction <- 
+    | conjunction ("or" conjunction )+
     | conjunction
-conjunction:
-    | inversion ('and' inversion )+
+conjunction <- 
+    | inversion ("and" inversion )+
     | inversion
-inversion:
-    | 'not' inversion
+inversion <- 
+    | "not" inversion
     | comparison
-comparison:
+comparison <- 
     | bitwise_or compare_op_bitwise_or_pair+
     | bitwise_or
-compare_op_bitwise_or_pair:
+compare_op_bitwise_or_pair <- 
     | eq_bitwise_or
     | noteq_bitwise_or
     | lte_bitwise_or
@@ -455,179 +456,225 @@ compare_op_bitwise_or_pair:
     | in_bitwise_or
     | isnot_bitwise_or
     | is_bitwise_or
-eq_bitwise_or: '==' bitwise_or
-noteq_bitwise_or:
-    | ('!=' ) bitwise_or
-lte_bitwise_or: '<=' bitwise_or
-lt_bitwise_or: '<' bitwise_or
-gte_bitwise_or: '>=' bitwise_or
-gt_bitwise_or: '>' bitwise_or
-notin_bitwise_or: 'not' 'in' bitwise_or
-in_bitwise_or: 'in' bitwise_or
-isnot_bitwise_or: 'is' 'not' bitwise_or
-is_bitwise_or: 'is' bitwise_or
+eq_bitwise_or <-  "==" bitwise_or
+noteq_bitwise_or <- 
+    | ("!=" ) bitwise_or
+lte_bitwise_or <-  "<=" bitwise_or
+lt_bitwise_or <-  "<" bitwise_or
+gte_bitwise_or <-  ">=" bitwise_or
+gt_bitwise_or <-  ">" bitwise_or
+notin_bitwise_or <-  "not" "in" bitwise_or
+in_bitwise_or <-  "in" bitwise_or
+isnot_bitwise_or <-  "is" "not" bitwise_or
+is_bitwise_or <-  "is" bitwise_or
 
-bitwise_or:
-    | bitwise_or '|' bitwise_xor
+bitwise_or <- 
+    | bitwise_or "|" bitwise_xor
     | bitwise_xor
-bitwise_xor:
-    | bitwise_xor '^' bitwise_and
+bitwise_xor <- 
+    | bitwise_xor "^" bitwise_and
     | bitwise_and
-bitwise_and:
-    | bitwise_and '&' shift_expr
+bitwise_and <- 
+    | bitwise_and "&" shift_expr
     | shift_expr
-shift_expr:
-    | shift_expr '<<' sum
-    | shift_expr '>>' sum
+shift_expr <- 
+    | shift_expr "<<" sum
+    | shift_expr ">>" sum
     | sum
 
-sum:
-    | sum '+' term
-    | sum '-' term
+sum <- 
+    | sum "+" term
+    | sum "-" term
     | term
-term:
-    | term '*' factor
-    | term '/' factor
-    | term '//' factor
-    | term '%' factor
-    | term '@' factor
+term <- 
+    | term "*" factor
+    | term "/" factor
+    | term "//" factor
+    | term "%" factor
+    | term "@" factor
     | factor
-factor:
-    | '+' factor
-    | '-' factor
-    | '~' factor
+factor <- 
+    | "+" factor
+    | "-" factor
+    | "~" factor
     | power
-power:
-    | await_primary '**' factor
+power <- 
+    | await_primary "**" factor
     | await_primary
-await_primary:
-    | AWAIT primary
-    | primary
-primary:
-    | primary '.' NAME
+await_primary <- 
+      "await" primary
+    / primary
+primary <- 
+    | primary "." NAME
     | primary genexp
-    | primary '(' [arguments] ')'
-    | primary '[' slices ']'
+    | primary "(" [arguments] ")"
+    | primary "[" slices "]"
     | atom
 
-slices:
-    | slice !','
-    | ','.slice+ [',']
-slice:
-    | [expression] ':' [expression] [':' [expression] ]
+slices <- 
+    | slice !","
+    | ",".slice+ [","]
+slice <- 
+    | [expression] ":" [expression] (":"  expression? )?
     | named_expression
-atom:
+atom <- 
     | NAME
-    | 'True'
-    | 'False'
-    | 'None'
+    | "True"
+    | "False"
+    | "None"
     | strings
     | NUMBER
     | (tuple | group | genexp)
     | (list | listcomp)
     | (dict | set | dictcomp | setcomp)
-    | '...'
+    | "..."
 
-strings: STRING+
-list:
-    | '[' [star_named_expressions] ']'
-listcomp:
-    | '[' named_expression for_if_clauses ']'
-tuple:
-    | '(' [star_named_expression ',' [star_named_expressions]  ] ')'
-group:
-    | '(' (yield_expr | named_expression) ')'
-genexp:
-    | '(' ( assignment_expression | expression !':=') for_if_clauses ')'
-set: '{' star_named_expressions '}'
-setcomp:
-    | '{' named_expression for_if_clauses '}'
-dict:
-    | '{' [double_starred_kvpairs] '}'
+strings <-  STRING+
+list <- 
+    | "[" [star_named_expressions] "]"
+listcomp <- 
+    | "[" named_expression for_if_clauses "]"
+tuple <-
+      "(" (star_named_expression ","  star_named_expressions?  )? ")"
+group <- 
+    | "(" (yield_expr | named_expression) ")"
+genexp <- 
+    | "(" ( assignment_expression | expression !":=") for_if_clauses ")"
+set <-  "{" star_named_expressions "}"
+setcomp <- 
+    | "{" named_expression for_if_clauses "}"
+dict <- 
+    | "{" [double_starred_kvpairs] "}"
 
-dictcomp:
-    | '{' kvpair for_if_clauses '}'
-double_starred_kvpairs: ','.double_starred_kvpair+ [',']
-double_starred_kvpair:
-    | '**' bitwise_or
+dictcomp <- 
+    | "{" kvpair for_if_clauses "}"
+double_starred_kvpairs <-  ",".double_starred_kvpair+ [","]
+double_starred_kvpair <- 
+    | "**" bitwise_or
     | kvpair
-kvpair: expression ':' expression
-for_if_clauses:
+kvpair <-  expression ":" expression
+for_if_clauses <- 
     | for_if_clause+
-for_if_clause:
-    | ASYNC 'for' star_targets 'in' ~ disjunction ('if' disjunction )*
-    | 'for' star_targets 'in' ~ disjunction ('if' disjunction )*
+for_if_clause <- 
+    | ASYNC "for" star_targets "in" ~ disjunction ("if" disjunction )*
+    | "for" star_targets "in" ~ disjunction ("if" disjunction )*
 
-yield_expr:
-    | 'yield' 'from' expression
-    | 'yield' [star_expressions]
+yield_expr <- 
+    | "yield" "from" expression
+    | "yield" [star_expressions]
 
-arguments:
-    | args [','] &')'
-args:
-    | ','.(starred_expression | ( assignment_expression | expression !':=') !'=')+ [',' kwargs ]
+arguments <- 
+    | args [","] &")"
+args <- 
+    | ",".(starred_expression | ( assignment_expression | expression !":=") !"=")+ ["," kwargs ]
     | kwargs
 
-kwargs:
-    | ','.kwarg_or_starred+ ',' ','.kwarg_or_double_starred+
-    | ','.kwarg_or_starred+
-    | ','.kwarg_or_double_starred+
-starred_expression:
-    | '*' expression
-kwarg_or_starred:
-    | NAME '=' expression
+kwargs <- 
+    | ",".kwarg_or_starred+ "," ",".kwarg_or_double_starred+
+    | ",".kwarg_or_starred+
+    | ",".kwarg_or_double_starred+
+starred_expression <- 
+    | "*" expression
+kwarg_or_starred <- 
+    | NAME "=" expression
     | starred_expression
-kwarg_or_double_starred:
-    | NAME '=' expression
-    | '**' expression
+kwarg_or_double_starred <- 
+    | NAME "=" expression
+    | "**" expression
 
 # NOTE: star_targets may contain *bitwise_or, targets may not.
-star_targets:
-    | star_target !','
-    | star_target (',' star_target )* [',']
-star_targets_list_seq: ','.star_target+ [',']
-star_targets_tuple_seq:
-    | star_target (',' star_target )+ [',']
-    | star_target ','
-star_target:
-    | '*' (!'*' star_target)
+star_targets <- 
+    | star_target !","
+    | star_target ("," star_target )* [","]
+star_targets_list_seq <-  ",".star_target+ [","]
+star_targets_tuple_seq <- 
+    | star_target ("," star_target )+ [","]
+    | star_target ","
+star_target <- 
+    | "*" (!"*" star_target)
     | target_with_star_atom
-target_with_star_atom:
-    | t_primary '.' NAME !t_lookahead
-    | t_primary '[' slices ']' !t_lookahead
+target_with_star_atom <- 
+    | t_primary "." NAME !t_lookahead
+    | t_primary "[" slices "]" !t_lookahead
     | star_atom
-star_atom:
+star_atom <- 
     | NAME
-    | '(' target_with_star_atom ')'
-    | '(' [star_targets_tuple_seq] ')'
-    | '[' [star_targets_list_seq] ']'
+    | "(" target_with_star_atom ")"
+    | "(" [star_targets_tuple_seq] ")"
+    | "[" [star_targets_list_seq] "]"
 
-single_target:
+single_target <- 
     | single_subscript_attribute_target
     | NAME
-    | '(' single_target ')'
-single_subscript_attribute_target:
-    | t_primary '.' NAME !t_lookahead
-    | t_primary '[' slices ']' !t_lookahead
+    | "(" single_target ")"
+single_subscript_attribute_target <- 
+    | t_primary "." NAME !t_lookahead
+    | t_primary "[" slices "]" !t_lookahead
 
-del_targets: ','.del_target+ [',']
-del_target:
-    | t_primary '.' NAME !t_lookahead
-    | t_primary '[' slices ']' !t_lookahead
+del_targets <-  ",".del_target+ [","]
+del_target <- 
+    | t_primary "." NAME !t_lookahead
+    | t_primary "[" slices "]" !t_lookahead
     | del_t_atom
-del_t_atom:
+del_t_atom <- 
     | NAME
-    | '(' del_target ')'
-    | '(' [del_targets] ')'
-    | '[' [del_targets] ']'
+    | "(" del_target ")"
+    | "(" [del_targets] ")"
+    | "[" [del_targets] "]"
 
-t_primary:
-    | t_primary '.' NAME &t_lookahead
-    | t_primary '[' slices ']' &t_lookahead
+t_primary <- 
+    | t_primary "." NAME &t_lookahead
+    | t_primary "[" slices "]" &t_lookahead
     | t_primary genexp &t_lookahead
-    | t_primary '(' [arguments] ')' &t_lookahead
+    | t_primary "(" [arguments] ")" &t_lookahead
     | atom &t_lookahead
-t_lookahead: '(' | '[' | '.'
+t_lookahead <-  "(" | "[" | "."
+
+STRING <- doublequote (DQChar)* doublequote StringPostfix?
+
+DQChar <- EscapeSequence
+        / !doublequote .
+
+EscapeSequence <- backslash ( quote
+                            / doublequote
+                            / backslash
+                            / [abfnrtv]
+                            / 'x' HexDigit HexDigit
+                            / 'u' HexDigit HexDigit HexDigit HexDigit
+                            / 'U' HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit HexDigit
+                            )
+
+StringPostfix < "c" / "w" / "d"
+
+
+ASYNC <- "async"
+
+NAME <~ !Keyword [a-zA-Z_] [a-zA-Z0-9_]*
+Keyword <- "abstract" / "alias" / "align" / "asm" / "assert" / "auto" / "await"
+	/ "body" / "bool" / "break" / "byte"
+
+NUMBER <- IntegerLiteral / FloatLiteral
+
+IntegerLiteral <- DecimalInteger
+                / BinaryInteger
+                / HexadecimalInteger
+
+DecimalInteger <- Integer IntegerSuffix?
+
+Integer <- digit (digit/"_")*
+
+IntegerSuffix <- "Lu" / "LU" / "uL" / "UL"
+               / "L" / "u" / "U"
+
+BinaryInteger <- ("0b" / "0B") [01] ([01] / "_")*
+
+HexadecimalInteger <- ("0x"/"0X") HexDigit (HexDigit / "_")*
+
+HexDigit < [0-9a-fA-F]
+
+FloatLiteral <- Sign? Integer "." Integer? (("e" / "E") Sign? Integer)?
+
+Sign <- ("-" / "+")?
 `;
 
 

--- a/examples/python/src/pegged/examples/python.d
+++ b/examples/python/src/pegged/examples/python.d
@@ -524,7 +524,7 @@ atom <-
     / "None"
     / strings
     / NUMBER
-    / (tuple | group | genexp)
+    / (tuple_expr | group | genexp)
     / (list | listcomp)
     / (dict | set | dictcomp | setcomp)
     / "..."
@@ -534,7 +534,7 @@ list <-
     / "[" [star_named_expressions] "]"
 listcomp <- 
     / "[" named_expression for_if_clauses "]"
-tuple <-
+tuple_expr <-
       "(" (star_named_expression ","  star_named_expressions?  )? ")"
 group <- 
     / "(" (yield_expr | named_expression) ")"

--- a/examples/python/src/pegged/examples/python.d
+++ b/examples/python/src/pegged/examples/python.d
@@ -689,6 +689,12 @@ DEDENT <- endOfLine
 NEWLINE <- endOfLine
 
 TYPE_COMMENT <- "#" "type" ":"
+
+Spacing <- (space / Comment)*
+
+Comment <- 
+         / LineComment
+LineComment <~ :'#' (!endOfLine .)* :endOfLine
 `;
 
 

--- a/examples/python/src/pegged/examples/python.d
+++ b/examples/python/src/pegged/examples/python.d
@@ -686,11 +686,9 @@ Sign <- ("-" / "+")?
 
 INDENT <- "\t" / " "
 DEDENT <- endOfLine
-NEWLINE <- endOfLine
+NEWLINE <- Comment endOfLine
 
 TYPE_COMMENT <- "#" "type" ":"
-
-Spacing <- (space / Comment)*
 
 Comment <- 
          / LineComment

--- a/examples/python/src/pegged/examples/python.d
+++ b/examples/python/src/pegged/examples/python.d
@@ -18,72 +18,72 @@ fstring <-  star_expressions
 
 # type_expressions allow */** but ignore them
 type_expressions <- 
-    | ",".expression+ "," "*" expression "," "**" expression
-    | ",".expression+ "," "*" expression
-    | ",".expression+ "," "**" expression
-    | "*" expression "," "**" expression
-    | "*" expression
-    | "**" expression
-    | ",".expression+
+    / ",".expression+ "," "*" expression "," "**" expression
+    / ",".expression+ "," "*" expression
+    / ",".expression+ "," "**" expression
+    / "*" expression "," "**" expression
+    / "*" expression
+    / "**" expression
+    / ",".expression+
 
 statements <-  statement+
-statement <-  compound_stmt  | simple_stmts
+statement <-  compound_stmt  / simple_stmts
 statement_newline <- 
-    | compound_stmt NEWLINE
-    | simple_stmts
-    | NEWLINE
-#   | ENDMARKER
+    / compound_stmt NEWLINE
+    / simple_stmts
+    / NEWLINE
+#   / ENDMARKER
 simple_stmts <- 
-    | simple_stmt !";" NEWLINE  # Not needed, there for speedup
-    | ";".simple_stmt+ [";"] NEWLINE
+    / simple_stmt !";" NEWLINE  # Not needed, there for speedup
+    / ";".simple_stmt+ [";"] NEWLINE
 # NOTE <-  assignment MUST precede expression, else parsing a simple assignment
 # will throw a SyntaxError.
 simple_stmt <- 
-    | assignment
-    | star_expressions
-    | return_stmt
-    | import_stmt
-    | raise_stmt
-    | "pass"
-    | del_stmt
-    | yield_stmt
-    | assert_stmt
-    | "break"
-    | "continue"
-    | global_stmt
-    | nonlocal_stmt
+    / assignment
+    / star_expressions
+    / return_stmt
+    / import_stmt
+    / raise_stmt
+    / "pass"
+    / del_stmt
+    / yield_stmt
+    / assert_stmt
+    / "break"
+    / "continue"
+    / global_stmt
+    / nonlocal_stmt
 compound_stmt <- 
-    | function_def
-    | if_stmt
-    | class_def
-    | with_stmt
-    | for_stmt
-    | try_stmt
-    | while_stmt
-    | match_stmt
+    / function_def
+    / if_stmt
+    / class_def
+    / with_stmt
+    / for_stmt
+    / try_stmt
+    / while_stmt
+    / match_stmt
 
 # NOTE: annotated_rhs may start with "yield"; yield_expr must start with "yield"
 assignment <- 
-    | NAME ":" expression ["=" annotated_rhs ]
-    | ("(" single_target ")"
-         | single_subscript_attribute_target) ":" expression ["=" annotated_rhs ]
-    | (star_targets "=" )+ (yield_expr | star_expressions) !"=" [TYPE_COMMENT]
-    | single_target augassign ~ (yield_expr | star_expressions)
+    / NAME ":" expression ["=" annotated_rhs ]
+    / ("(" single_target ")"
+         / single_subscript_attribute_target) ":" expression ["=" annotated_rhs ]
+    / (star_targets "=" )+ (yield_expr | star_expressions) !"=" [TYPE_COMMENT]
+    / single_target augassign ~ (yield_expr | star_expressions)
 
 augassign <- 
-    | "+="
-    | "-="
-    | "*="
-    | "@="
-    | "/="
-    | "%="
-    | "&="
-    | "|="
-    | "^="
-    | "<<="
-    | ">>="
-    | "**="
-    | "//="
+    / "+="
+    / "-="
+    / "*="
+    / "@="
+    / "/="
+    / "%="
+    / "&="
+    / "|="
+    / "^="
+    / "<<="
+    / ">>="
+    / "**="
+    / "//="
 
 global_stmt <-  "global" ",".NAME+
 nonlocal_stmt <-  "nonlocal" ",".NAME+
@@ -93,230 +93,230 @@ yield_stmt <-  yield_expr
 assert_stmt <-  "assert" expression ["," expression ]
 
 del_stmt <- 
-    | "del" del_targets &(";" | NEWLINE)
+    / "del" del_targets &(";" | NEWLINE)
 
-import_stmt <-  import_name | import_from
+import_stmt <-  import_name / import_from
 import_name <-  "import" dotted_as_names
 # note below <-  the ("." | "...") is necessary because "..." is tokenized as ELLIPSIS
 import_from <- 
-    | "from" ("." | "...")* dotted_name "import" import_from_targets
-    | "from" ("." | "...")+ "import" import_from_targets
+    / "from" ("." | "...")* dotted_name "import" import_from_targets
+    / "from" ("." | "...")+ "import" import_from_targets
 import_from_targets <- 
-    | "(" import_from_as_names [","] ")"
-    | import_from_as_names !","
-    | "*"
+    / "(" import_from_as_names [","] ")"
+    / import_from_as_names !","
+    / "*"
 import_from_as_names <- 
-    | ",".import_from_as_name+
+    / ",".import_from_as_name+
 import_from_as_name <- 
-    | NAME ["as" NAME ]
+    / NAME ["as" NAME ]
 dotted_as_names <- 
-    | ",".dotted_as_name+
+    / ",".dotted_as_name+
 dotted_as_name <- 
-    | dotted_name ["as" NAME ]
+    / dotted_name ["as" NAME ]
 dotted_name <- 
-    | dotted_name "." NAME
-    | NAME
+    / dotted_name "." NAME
+    / NAME
 
 if_stmt <- 
-    | "if" named_expression ":" block elif_stmt
-    | "if" named_expression ":" block [else_block]
+    / "if" named_expression ":" block elif_stmt
+    / "if" named_expression ":" block [else_block]
 elif_stmt <- 
-    | "elif" named_expression ":" block elif_stmt
-    | "elif" named_expression ":" block [else_block]
+    / "elif" named_expression ":" block elif_stmt
+    / "elif" named_expression ":" block [else_block]
 else_block <- 
-    | "else" ":" block
+    / "else" ":" block
 
 while_stmt <- 
-    | "while" named_expression ":" block [else_block]
+    / "while" named_expression ":" block [else_block]
 
 for_stmt <- 
-    | "for" star_targets "in" ~ star_expressions ":" [TYPE_COMMENT] block [else_block]
-    | ASYNC "for" star_targets "in" ~ star_expressions ":" [TYPE_COMMENT] block [else_block]
+    / "for" star_targets "in" ~ star_expressions ":" [TYPE_COMMENT] block [else_block]
+    / ASYNC "for" star_targets "in" ~ star_expressions ":" [TYPE_COMMENT] block [else_block]
 
 with_stmt <- 
-    | "with" "(" ",".with_item+ ","? ")" ":" block
-    | "with" ",".with_item+ ":" [TYPE_COMMENT] block
-    | ASYNC "with" "(" ",".with_item+ ","? ")" ":" block
-    | ASYNC "with" ",".with_item+ ":" [TYPE_COMMENT] block
+    / "with" "(" ",".with_item+ ","? ")" ":" block
+    / "with" ",".with_item+ ":" [TYPE_COMMENT] block
+    / ASYNC "with" "(" ",".with_item+ ","? ")" ":" block
+    / ASYNC "with" ",".with_item+ ":" [TYPE_COMMENT] block
 
 with_item <- 
-    | expression "as" star_target &("," | ")" | ":")
-    | expression
+    / expression "as" star_target &("," | ")" | ":")
+    / expression
 
 try_stmt <- 
-    | "try" ":" block finally_block
-    | "try" ":" block except_block+ [else_block] [finally_block]
+    / "try" ":" block finally_block
+    / "try" ":" block except_block+ [else_block] [finally_block]
 except_block <- 
-    | "except" expression ["as" NAME ] ":" block
-    | "except" ":" block
+    / "except" expression ["as" NAME ] ":" block
+    / "except" ":" block
 finally_block <- 
-    | "finally" ":" block
+    / "finally" ":" block
 
 match_stmt <- 
-    | "match" subject_expr ":" NEWLINE INDENT case_block+ DEDENT
+    / "match" subject_expr ":" NEWLINE INDENT case_block+ DEDENT
 subject_expr <- 
-    | star_named_expression "," star_named_expressions?
-    | named_expression
+    / star_named_expression "," star_named_expressions?
+    / named_expression
 case_block <- 
-    | "case" patterns guard? ":" block
+    / "case" patterns guard? ":" block
 guard <-  "if" named_expression
 
 patterns <- 
-    | open_sequence_pattern
-    | pattern
+    / open_sequence_pattern
+    / pattern
 pattern <- 
-    | as_pattern
-    | or_pattern
+    / as_pattern
+    / or_pattern
 as_pattern <- 
-    | or_pattern "as" pattern_capture_target
+    / or_pattern "as" pattern_capture_target
 or_pattern <- 
-    | "|".closed_pattern+
+    / "|".closed_pattern+
 closed_pattern <- 
-    | literal_pattern
-    | capture_pattern
-    | wildcard_pattern
-    | value_pattern
-    | group_pattern
-    | sequence_pattern
-    | mapping_pattern
-    | class_pattern
+    / literal_pattern
+    / capture_pattern
+    / wildcard_pattern
+    / value_pattern
+    / group_pattern
+    / sequence_pattern
+    / mapping_pattern
+    / class_pattern
 
 # Literal patterns are used for equality and identity constraints
 literal_pattern <- 
-    | signed_number !("+" | "-")
-    | complex_number
-    | strings
-    | "None"
-    | "True"
-    | "False"
+    / signed_number !("+" | "-")
+    / complex_number
+    / strings
+    / "None"
+    / "True"
+    / "False"
 
 # Literal expressions are used to restrict permitted mapping pattern keys
 literal_expr <- 
-    | signed_number !("+" | "-")
-    | complex_number
-    | strings
-    | "None"
-    | "True"
-    | "False"
+    / signed_number !("+" | "-")
+    / complex_number
+    / strings
+    / "None"
+    / "True"
+    / "False"
 
 complex_number <- 
-    | signed_real_number "+" imaginary_number
-    | signed_real_number "-" imaginary_number
+    / signed_real_number "+" imaginary_number
+    / signed_real_number "-" imaginary_number
 
 signed_number <- 
-    | NUMBER
-    | "-" NUMBER
+    / NUMBER
+    / "-" NUMBER
 
 signed_real_number <- 
-    | real_number
-    | "-" real_number
+    / real_number
+    / "-" real_number
 
 real_number <- 
-    | NUMBER
+    / NUMBER
 
 imaginary_number <- 
-    | NUMBER
+    / NUMBER
 
 capture_pattern <- 
-    | pattern_capture_target
+    / pattern_capture_target
 
 pattern_capture_target <- 
-    | !"_" NAME !("." | "(" | "=")
+    / !"_" NAME !("." | "(" | "=")
 
 wildcard_pattern <- 
-    | "_"
+    / "_"
 
 value_pattern <- 
-    | attr !("." | "(" | "=")
+    / attr !("." | "(" | "=")
 attr <- 
-    | name_or_attr "." NAME
+    / name_or_attr "." NAME
 name_or_attr <- 
-    | attr
-    | NAME
+    / attr
+    / NAME
 
 group_pattern <- 
-    | "(" pattern ")"
+    / "(" pattern ")"
 
 sequence_pattern <- 
-    | "[" maybe_sequence_pattern? "]"
-    | "(" open_sequence_pattern? ")"
+    / "[" maybe_sequence_pattern? "]"
+    / "(" open_sequence_pattern? ")"
 open_sequence_pattern <- 
-    | maybe_star_pattern "," maybe_sequence_pattern?
+    / maybe_star_pattern "," maybe_sequence_pattern?
 maybe_sequence_pattern <- 
-    | ",".maybe_star_pattern+ ","?
+    / ",".maybe_star_pattern+ ","?
 maybe_star_pattern <- 
-    | star_pattern
-    | pattern
+    / star_pattern
+    / pattern
 star_pattern <- 
-    | "*" pattern_capture_target
-    | "*" wildcard_pattern
+    / "*" pattern_capture_target
+    / "*" wildcard_pattern
 
 mapping_pattern <- 
-    | "{" "}"
-    | "{" double_star_pattern ","? "}"
-    | "{" items_pattern "," double_star_pattern ","? "}"
-    | "{" items_pattern ","? "}"
+    / "{" "}"
+    / "{" double_star_pattern ","? "}"
+    / "{" items_pattern "," double_star_pattern ","? "}"
+    / "{" items_pattern ","? "}"
 items_pattern <- 
-    | ",".key_value_pattern+
+    / ",".key_value_pattern+
 key_value_pattern <- 
-    | (literal_expr | attr) ":" pattern
+    / (literal_expr | attr) ":" pattern
 double_star_pattern <- 
-    | "**" pattern_capture_target
+    / "**" pattern_capture_target
 
 class_pattern <- 
-    | name_or_attr "(" ")"
-    | name_or_attr "(" positional_patterns ","? ")"
-    | name_or_attr "(" keyword_patterns ","? ")"
-    | name_or_attr "(" positional_patterns "," keyword_patterns ","? ")"
+    / name_or_attr "(" ")"
+    / name_or_attr "(" positional_patterns ","? ")"
+    / name_or_attr "(" keyword_patterns ","? ")"
+    / name_or_attr "(" positional_patterns "," keyword_patterns ","? ")"
 positional_patterns <- 
-    | ",".pattern+
+    / ",".pattern+
 keyword_patterns <- 
-    | ",".keyword_pattern+
+    / ",".keyword_pattern+
 keyword_pattern <- 
-    | NAME "=" pattern
+    / NAME "=" pattern
 
 return_stmt <- 
-    | "return" [star_expressions]
+    / "return" [star_expressions]
 
 raise_stmt <- 
-    | "raise" expression ["from" expression ]
-    | "raise"
+    / "raise" expression ["from" expression ]
+    / "raise"
 
 function_def <- 
-    | decorators function_def_raw
-    | function_def_raw
+    / decorators function_def_raw
+    / function_def_raw
 
 function_def_raw <- 
-    | "def" NAME "(" [params] ")" ["->" expression ] ":" [func_type_comment] block
-    | ASYNC "def" NAME "(" [params] ")" ["->" expression ] ":" [func_type_comment] block
+    / "def" NAME "(" [params] ")" ["->" expression ] ":" [func_type_comment] block
+    / ASYNC "def" NAME "(" [params] ")" ["->" expression ] ":" [func_type_comment] block
 func_type_comment <- 
-    | NEWLINE TYPE_COMMENT &(NEWLINE INDENT)   # Must be followed by indented block
-    | TYPE_COMMENT
+    / NEWLINE TYPE_COMMENT &(NEWLINE INDENT)   # Must be followed by indented block
+    / TYPE_COMMENT
 
 params <- 
-    | parameters
+    / parameters
 
 parameters <- 
-    | slash_no_default param_no_default* param_with_default* [star_etc]
-    | slash_with_default param_with_default* [star_etc]
-    | param_no_default+ param_with_default* [star_etc]
-    | param_with_default+ [star_etc]
-    | star_etc
+    / slash_no_default param_no_default* param_with_default* [star_etc]
+    / slash_with_default param_with_default* [star_etc]
+    / param_no_default+ param_with_default* [star_etc]
+    / param_with_default+ [star_etc]
+    / star_etc
 
 # Some duplication here because we can't write ("," | &")"),
 # which is because we don't support empty alternatives (yet).
 #
 slash_no_default <- 
-    | param_no_default+ "/" ","
-    | param_no_default+ "/" &")"
+    / param_no_default+ "/" ","
+    / param_no_default+ "/" &")"
 slash_with_default <- 
-    | param_no_default* param_with_default+ "/" ","
-    | param_no_default* param_with_default+ "/" &")"
+    / param_no_default* param_with_default+ "/" ","
+    / param_no_default* param_with_default+ "/" &")"
 
 star_etc <- 
-    | "*" param_no_default param_maybe_default* [kwds]
-    | "*" "," param_maybe_default+ [kwds]
-    | kwds
+    / "*" param_no_default param_maybe_default* [kwds]
+    / "*" "," param_maybe_default+ [kwds]
+    / kwds
 
 kwds <-  "**" param_no_default
 
@@ -333,14 +333,14 @@ kwds <-  "**" param_no_default
 # The latter form is for a final parameter without trailing comma.
 #
 param_no_default <- 
-    | param "," TYPE_COMMENT?
-    | param TYPE_COMMENT? &")"
+    / param "," TYPE_COMMENT?
+    / param TYPE_COMMENT? &")"
 param_with_default <- 
-    | param default_expr "," TYPE_COMMENT?
-    | param default_expr TYPE_COMMENT? &")"
+    / param default_expr "," TYPE_COMMENT?
+    / param default_expr TYPE_COMMENT? &")"
 param_maybe_default <- 
-    | param default_expr? "," TYPE_COMMENT?
-    | param default_expr? TYPE_COMMENT? &")"
+    / param default_expr? "," TYPE_COMMENT?
+    / param default_expr? TYPE_COMMENT? &")"
 param <-  NAME annotation?
 
 annotation <-  ":" expression
@@ -349,116 +349,116 @@ default_expr <-  "=" expression
 decorators <-  ("@" named_expression NEWLINE )+
 
 class_def <- 
-    | decorators class_def_raw
-    | class_def_raw
+    / decorators class_def_raw
+    / class_def_raw
 
 class_def_raw <-
-    | "class" NAME ("(" arguments? ")")? ":" block
+    / "class" NAME ("(" arguments? ")")? ":" block
 
 block <- 
-    | NEWLINE INDENT statements DEDENT
-    | simple_stmts
+    / NEWLINE INDENT statements DEDENT
+    / simple_stmts
 
 star_expressions <- 
-    | star_expression ("," star_expression )+ [","]
-    | star_expression ","
-    | star_expression
+    / star_expression ("," star_expression )+ [","]
+    / star_expression ","
+    / star_expression
 star_expression <- 
-    | "*" bitwise_or
-    | expression
+    / "*" bitwise_or
+    / expression
 
 star_named_expressions <-  ",".star_named_expression+ [","]
 star_named_expression <- 
-    | "*" bitwise_or
-    | named_expression
+    / "*" bitwise_or
+    / named_expression
 
 
 assignment_expression <- 
-    | NAME ":=" ~ expression
+    / NAME ":=" ~ expression
 
 named_expression <- 
-    | assignment_expression
-    | expression !":="
+    / assignment_expression
+    / expression !":="
 
-annotated_rhs <-  yield_expr | star_expressions
+annotated_rhs <-  yield_expr / star_expressions
 
 expressions <- 
-    | expression ("," expression )+ [","]
-    | expression ","
-    | expression
+    / expression ("," expression )+ [","]
+    / expression ","
+    / expression
 expression <- 
-    | disjunction "if" disjunction "else" expression
-    | disjunction
-    | lambdef
+    / disjunction "if" disjunction "else" expression
+    / disjunction
+    / lambdef
 
 lambdef <- 
-    | "lambda" [lambda_params] ":" expression
+    / "lambda" [lambda_params] ":" expression
 
 lambda_params <- 
-    | lambda_parameters
+    / lambda_parameters
 
 # lambda_parameters etc. duplicates parameters but without annotations
 # or type comments, and if there's no comma after a parameter, we expect
 # a colon, not a close parenthesis.  (For more, see parameters above.)
 #
 lambda_parameters <- 
-    | lambda_slash_no_default lambda_param_no_default* lambda_param_with_default* [lambda_star_etc]
-    | lambda_slash_with_default lambda_param_with_default* [lambda_star_etc]
-    | lambda_param_no_default+ lambda_param_with_default* [lambda_star_etc]
-    | lambda_param_with_default+ [lambda_star_etc]
-    | lambda_star_etc
+    / lambda_slash_no_default lambda_param_no_default* lambda_param_with_default* [lambda_star_etc]
+    / lambda_slash_with_default lambda_param_with_default* [lambda_star_etc]
+    / lambda_param_no_default+ lambda_param_with_default* [lambda_star_etc]
+    / lambda_param_with_default+ [lambda_star_etc]
+    / lambda_star_etc
 
 lambda_slash_no_default <- 
-    | lambda_param_no_default+ "/" ","
-    | lambda_param_no_default+ "/" &":"
+    / lambda_param_no_default+ "/" ","
+    / lambda_param_no_default+ "/" &":"
 lambda_slash_with_default <- 
-    | lambda_param_no_default* lambda_param_with_default+ "/" ","
-    | lambda_param_no_default* lambda_param_with_default+ "/" &":"
+    / lambda_param_no_default* lambda_param_with_default+ "/" ","
+    / lambda_param_no_default* lambda_param_with_default+ "/" &":"
 
 lambda_star_etc <- 
-    | "*" lambda_param_no_default lambda_param_maybe_default* [lambda_kwds]
-    | "*" "," lambda_param_maybe_default+ [lambda_kwds]
-    | lambda_kwds
+    / "*" lambda_param_no_default lambda_param_maybe_default* [lambda_kwds]
+    / "*" "," lambda_param_maybe_default+ [lambda_kwds]
+    / lambda_kwds
 
 lambda_kwds <-  "**" lambda_param_no_default
 
 lambda_param_no_default <- 
-    | lambda_param ","
-    | lambda_param &":"
+    / lambda_param ","
+    / lambda_param &":"
 lambda_param_with_default <- 
-    | lambda_param default_expr ","
-    | lambda_param default_expr &":"
+    / lambda_param default_expr ","
+    / lambda_param default_expr &":"
 lambda_param_maybe_default <- 
-    | lambda_param default_expr? ","
-    | lambda_param default_expr? &":"
+    / lambda_param default_expr? ","
+    / lambda_param default_expr? &":"
 lambda_param <-  NAME
 
 disjunction <- 
-    | conjunction ("or" conjunction )+
-    | conjunction
+    / conjunction ("or" conjunction )+
+    / conjunction
 conjunction <- 
-    | inversion ("and" inversion )+
-    | inversion
+    / inversion ("and" inversion )+
+    / inversion
 inversion <- 
-    | "not" inversion
-    | comparison
+    / "not" inversion
+    / comparison
 comparison <- 
-    | bitwise_or compare_op_bitwise_or_pair+
-    | bitwise_or
+    / bitwise_or compare_op_bitwise_or_pair+
+    / bitwise_or
 compare_op_bitwise_or_pair <- 
-    | eq_bitwise_or
-    | noteq_bitwise_or
-    | lte_bitwise_or
-    | lt_bitwise_or
-    | gte_bitwise_or
-    | gt_bitwise_or
-    | notin_bitwise_or
-    | in_bitwise_or
-    | isnot_bitwise_or
-    | is_bitwise_or
+    / eq_bitwise_or
+    / noteq_bitwise_or
+    / lte_bitwise_or
+    / lt_bitwise_or
+    / gte_bitwise_or
+    / gt_bitwise_or
+    / notin_bitwise_or
+    / in_bitwise_or
+    / isnot_bitwise_or
+    / is_bitwise_or
 eq_bitwise_or <-  "==" bitwise_or
 noteq_bitwise_or <- 
-    | ("!=" ) bitwise_or
+    / ("!=" ) bitwise_or
 lte_bitwise_or <-  "<=" bitwise_or
 lt_bitwise_or <-  "<" bitwise_or
 gte_bitwise_or <-  ">=" bitwise_or
@@ -469,166 +469,166 @@ isnot_bitwise_or <-  "is" "not" bitwise_or
 is_bitwise_or <-  "is" bitwise_or
 
 bitwise_or <- 
-    | bitwise_or "|" bitwise_xor
-    | bitwise_xor
+    / bitwise_or "|" bitwise_xor
+    / bitwise_xor
 bitwise_xor <- 
-    | bitwise_xor "^" bitwise_and
-    | bitwise_and
+    / bitwise_xor "^" bitwise_and
+    / bitwise_and
 bitwise_and <- 
-    | bitwise_and "&" shift_expr
-    | shift_expr
+    / bitwise_and "&" shift_expr
+    / shift_expr
 shift_expr <- 
-    | shift_expr "<<" sum
-    | shift_expr ">>" sum
-    | sum
+    / shift_expr "<<" sum
+    / shift_expr ">>" sum
+    / sum
 
 sum <- 
-    | sum "+" term
-    | sum "-" term
-    | term
+    / sum "+" term
+    / sum "-" term
+    / term
 term <- 
-    | term "*" factor
-    | term "/" factor
-    | term "//" factor
-    | term "%" factor
-    | term "@" factor
-    | factor
+    / term "*" factor
+    / term "/" factor
+    / term "//" factor
+    / term "%" factor
+    / term "@" factor
+    / factor
 factor <- 
-    | "+" factor
-    | "-" factor
-    | "~" factor
-    | power
+    / "+" factor
+    / "-" factor
+    / "~" factor
+    / power
 power <- 
-    | await_primary "**" factor
-    | await_primary
+    / await_primary "**" factor
+    / await_primary
 await_primary <- 
       "await" primary
     / primary
 primary <- 
-    | primary "." NAME
-    | primary genexp
-    | primary "(" [arguments] ")"
-    | primary "[" slices "]"
-    | atom
+    / primary "." NAME
+    / primary genexp
+    / primary "(" [arguments] ")"
+    / primary "[" slices "]"
+    / atom
 
 slices <- 
-    | slice !","
-    | ",".slice+ [","]
+    / slice !","
+    / ",".slice+ [","]
 slice <- 
-    | [expression] ":" [expression] (":"  expression? )?
-    | named_expression
+    / [expression] ":" [expression] (":"  expression? )?
+    / named_expression
 atom <- 
-    | NAME
-    | "True"
-    | "False"
-    | "None"
-    | strings
-    | NUMBER
-    | (tuple | group | genexp)
-    | (list | listcomp)
-    | (dict | set | dictcomp | setcomp)
-    | "..."
+    / NAME
+    / "True"
+    / "False"
+    / "None"
+    / strings
+    / NUMBER
+    / (tuple | group | genexp)
+    / (list | listcomp)
+    / (dict | set | dictcomp | setcomp)
+    / "..."
 
 strings <-  STRING+
 list <- 
-    | "[" [star_named_expressions] "]"
+    / "[" [star_named_expressions] "]"
 listcomp <- 
-    | "[" named_expression for_if_clauses "]"
+    / "[" named_expression for_if_clauses "]"
 tuple <-
       "(" (star_named_expression ","  star_named_expressions?  )? ")"
 group <- 
-    | "(" (yield_expr | named_expression) ")"
+    / "(" (yield_expr | named_expression) ")"
 genexp <- 
-    | "(" ( assignment_expression | expression !":=") for_if_clauses ")"
+    / "(" ( assignment_expression | expression !":=") for_if_clauses ")"
 set <-  "{" star_named_expressions "}"
 setcomp <- 
-    | "{" named_expression for_if_clauses "}"
+    / "{" named_expression for_if_clauses "}"
 dict <- 
-    | "{" [double_starred_kvpairs] "}"
+    / "{" [double_starred_kvpairs] "}"
 
 dictcomp <- 
-    | "{" kvpair for_if_clauses "}"
+    / "{" kvpair for_if_clauses "}"
 double_starred_kvpairs <-  ",".double_starred_kvpair+ [","]
 double_starred_kvpair <- 
-    | "**" bitwise_or
-    | kvpair
+    / "**" bitwise_or
+    / kvpair
 kvpair <-  expression ":" expression
 for_if_clauses <- 
-    | for_if_clause+
+    / for_if_clause+
 for_if_clause <- 
-    | ASYNC "for" star_targets "in" ~ disjunction ("if" disjunction )*
-    | "for" star_targets "in" ~ disjunction ("if" disjunction )*
+    / ASYNC "for" star_targets "in" ~ disjunction ("if" disjunction )*
+    / "for" star_targets "in" ~ disjunction ("if" disjunction )*
 
 yield_expr <- 
-    | "yield" "from" expression
-    | "yield" [star_expressions]
+    / "yield" "from" expression
+    / "yield" [star_expressions]
 
 arguments <- 
-    | args [","] &")"
+    / args [","] &")"
 args <- 
-    | ",".(starred_expression | ( assignment_expression | expression !":=") !"=")+ ["," kwargs ]
-    | kwargs
+    / ",".(starred_expression | ( assignment_expression | expression !":=") !"=")+ ["," kwargs ]
+    / kwargs
 
 kwargs <- 
-    | ",".kwarg_or_starred+ "," ",".kwarg_or_double_starred+
-    | ",".kwarg_or_starred+
-    | ",".kwarg_or_double_starred+
+    / ",".kwarg_or_starred+ "," ",".kwarg_or_double_starred+
+    / ",".kwarg_or_starred+
+    / ",".kwarg_or_double_starred+
 starred_expression <- 
-    | "*" expression
+    / "*" expression
 kwarg_or_starred <- 
-    | NAME "=" expression
-    | starred_expression
+    / NAME "=" expression
+    / starred_expression
 kwarg_or_double_starred <- 
-    | NAME "=" expression
-    | "**" expression
+    / NAME "=" expression
+    / "**" expression
 
 # NOTE: star_targets may contain *bitwise_or, targets may not.
 star_targets <- 
-    | star_target !","
-    | star_target ("," star_target )* [","]
+    / star_target !","
+    / star_target ("," star_target )* [","]
 star_targets_list_seq <-  ",".star_target+ [","]
 star_targets_tuple_seq <- 
-    | star_target ("," star_target )+ [","]
-    | star_target ","
+    / star_target ("," star_target )+ [","]
+    / star_target ","
 star_target <- 
-    | "*" (!"*" star_target)
-    | target_with_star_atom
+    / "*" (!"*" star_target)
+    / target_with_star_atom
 target_with_star_atom <- 
-    | t_primary "." NAME !t_lookahead
-    | t_primary "[" slices "]" !t_lookahead
-    | star_atom
+    / t_primary "." NAME !t_lookahead
+    / t_primary "[" slices "]" !t_lookahead
+    / star_atom
 star_atom <- 
-    | NAME
-    | "(" target_with_star_atom ")"
-    | "(" [star_targets_tuple_seq] ")"
-    | "[" [star_targets_list_seq] "]"
+    / NAME
+    / "(" target_with_star_atom ")"
+    / "(" [star_targets_tuple_seq] ")"
+    / "[" [star_targets_list_seq] "]"
 
 single_target <- 
-    | single_subscript_attribute_target
-    | NAME
-    | "(" single_target ")"
+    / single_subscript_attribute_target
+    / NAME
+    / "(" single_target ")"
 single_subscript_attribute_target <- 
-    | t_primary "." NAME !t_lookahead
-    | t_primary "[" slices "]" !t_lookahead
+    / t_primary "." NAME !t_lookahead
+    / t_primary "[" slices "]" !t_lookahead
 
 del_targets <-  ",".del_target+ [","]
 del_target <- 
-    | t_primary "." NAME !t_lookahead
-    | t_primary "[" slices "]" !t_lookahead
-    | del_t_atom
+    / t_primary "." NAME !t_lookahead
+    / t_primary "[" slices "]" !t_lookahead
+    / del_t_atom
 del_t_atom <- 
-    | NAME
-    | "(" del_target ")"
-    | "(" [del_targets] ")"
-    | "[" [del_targets] "]"
+    / NAME
+    / "(" del_target ")"
+    / "(" [del_targets] ")"
+    / "[" [del_targets] "]"
 
 t_primary <- 
-    | t_primary "." NAME &t_lookahead
-    | t_primary "[" slices "]" &t_lookahead
-    | t_primary genexp &t_lookahead
-    | t_primary "(" [arguments] ")" &t_lookahead
-    | atom &t_lookahead
-t_lookahead <-  "(" | "[" | "."
+    / t_primary "." NAME &t_lookahead
+    / t_primary "[" slices "]" &t_lookahead
+    / t_primary genexp &t_lookahead
+    / t_primary "(" [arguments] ")" &t_lookahead
+    / atom &t_lookahead
+t_lookahead <-  "(" / "[" / "."
 
 STRING <- doublequote (DQChar)* doublequote StringPostfix?
 
@@ -677,6 +677,8 @@ FloatLiteral <- Sign? Integer "." Integer? (("e" / "E") Sign? Integer)?
 Sign <- ("-" / "+")?
 
 INDENT <- "\t" / " "
+DEDENT <- endOfLine
+NEWLINE <- endOfLine
 `;
 
 


### PR DESCRIPTION
Hi,

I tried to add python example, the syntax is taken from:

https://docs.python.org/3/reference/grammar.html

I made minimal modification to use Pegged syntax.

However, the `make test` is still not quite working, and as a Pegged newbie, I cannot figure out how to fix these compilation errors:

```
~/project/contrib/Pegged/examples/python$ make
dub test
Generating test runner configuration 'python-test-library' for 'library' (library).
Performing "unittest" build using /ldc2-1.28.0-linux-x86_64/bin/ldc2 for x86_64.
pegged 0.4.5+commit.5.g913d8dd: building configuration "default"...
python ~master: building configuration "python-test-library"...
../../pegged/peg.d(1842,9): Error: variable `pegged.examples.python.GenericPython!(ParseTree).GenericPython.Python.longest_match!(tuple, group, genexp).ctfeGetNameOr.rule` type `void` is inferred from initializer `tuple`, and variables cannot be of type `void`
../../pegged/peg.d(1842,25): Error: expression `tuple` is `void` and has no value
src/pegged/examples/python.d-mixin-681(6250,196): Error: template instance `pegged.examples.python.GenericPython!(ParseTree).GenericPython.Python.longest_match!(tuple, group, genexp)` error instantiating
src/pegged/examples/python.d-mixin-681(8204,7):        instantiated from here: `GenericPython!(ParseTree)`
src/pegged/examples/python.d-mixin-681(6250,245): Error: template instance `pegged.peg.longest_match!(list, listcomp)` does not match template declaration `longest_match(rules...)(ParseTree p)`
src/pegged/examples/python.d-mixin-681(6250,288): Error: template instance `pegged.peg.longest_match!(dict, set, dictcomp, setcomp)` does not match template declaration `longest_match(rules...)(ParseTree p)`
../../pegged/peg.d(535,20): Error: none of the overloads of `target_with_star_atom` are callable using argument types `(GetName)`
src/pegged/examples/python.d-mixin-681(7218,23):        Candidates are: `pegged.examples.python.GenericPython!(ParseTree).GenericPython.Python.target_with_star_atom(ParseTree p)`
src/pegged/examples/python.d-mixin-681(7237,23):                        `pegged.examples.python.GenericPython!(ParseTree).GenericPython.Python.target_with_star_atom(string s)`
../../pegged/peg.d(1843,21): Error: template instance `pegged.peg.getName!(target_with_star_atom)` error instantiating
src/pegged/examples/python.d-mixin-681(7186,59):        instantiated from here: `longest_match!(and, target_with_star_atom)`
src/pegged/examples/python.d-mixin-681(8204,7):        instantiated from here: `GenericPython!(ParseTree)`
../../pegged/peg.d(535,20): Error: none of the overloads of `disjunction` are callable using argument types `(GetName)`
src/pegged/examples/python.d-mixin-681(5155,23):        Candidates are: `pegged.examples.python.GenericPython!(ParseTree).GenericPython.Python.disjunction(ParseTree p)`
src/pegged/examples/python.d-mixin-681(5174,23):                        `pegged.examples.python.GenericPython!(ParseTree).GenericPython.Python.disjunction(string s)`
../../pegged/peg.d(3134,32): Error: template instance `pegged.peg.getName!(disjunction)` error instantiating
src/pegged/examples/python.d-mixin-681(6790,177):        instantiated from here: `fuse!(disjunction)`
src/pegged/examples/python.d-mixin-681(8204,7):        instantiated from here: `GenericPython!(ParseTree)`
../../pegged/peg.d(535,20): Error: none of the overloads of `for_if_clause` are callable using argument types `(GetName)`
src/pegged/examples/python.d-mixin-681(6786,23):        Candidates are: `pegged.examples.python.GenericPython!(ParseTree).GenericPython.Python.for_if_clause(ParseTree p)`
src/pegged/examples/python.d-mixin-681(6805,23):                        `pegged.examples.python.GenericPython!(ParseTree).GenericPython.Python.for_if_clause(string s)`
src/pegged/examples/python.d-mixin-681(6754,59): Error: template instance `pegged.peg.oneOrMore!(for_if_clause)` error instantiating
src/pegged/examples/python.d-mixin-681(8204,7):        instantiated from here: `GenericPython!(ParseTree)`
../../pegged/peg.d(535,20): Error: none of the overloads of `primary` are callable using argument types `(GetName)`
src/pegged/examples/python.d-mixin-681(6121,23):        Candidates are: `pegged.examples.python.GenericPython!(ParseTree).GenericPython.Python.primary(ParseTree p)`
src/pegged/examples/python.d-mixin-681(6157,23):                        `pegged.examples.python.GenericPython!(ParseTree).GenericPython.Python.primary(string s)`
../../pegged/peg.d(1642,21): Error: template instance `pegged.peg.getName!(primary)` error instantiating
src/pegged/examples/python.d-mixin-681(6097,76):        instantiated from here: `or!(and, primary)`
src/pegged/examples/python.d-mixin-681(8204,7):        instantiated from here: `GenericPython!(ParseTree)`
../../pegged/peg.d(535,20): Error: none of the overloads of `await_primary` are callable using argument types `(GetName)`
```

@veelo if you have time, can you help to fix these errors? then we can have Python here!

Thanks!