### PR TITLE
Remove deprecated -check-printf-calls dflag for LDC

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -18,7 +18,6 @@
     "importPaths": ["."],
     "dflags": ["-ignore"],
     "dflags-gdc": ["-ggdb"],
-    "dflags-ldc": ["-check-printf-calls"],
     "configurations": [
         {
             "name": "default"

--- a/wscript
+++ b/wscript
@@ -62,7 +62,6 @@ def configure(conf):
         add_option('-wi')
         add_option('-ignore')
         add_option('-property')
-        add_option('-check-printf-calls')
         add_option('-g')
 
         if conf.options.mode == 'debug':


### PR DESCRIPTION
It's deprecated since LDC v1.31, as `pragma(printf)` (used by `core.stdc.stdio`) is much better and supported by all compilers. Additionally, I haven't found a single `printf` occurrence in this repo here.