### PR TITLE
fix(peg): use GC allocated slice instead of always alloca on stack

### DIFF
--- a/pegged/peg.d
+++ b/pegged/peg.d
@@ -1664,9 +1664,9 @@ template or(rules...) if (rules.length > 0)
         size_t errorStringChars;
         string orErrorString;
 
-        ParseTree[rules.length] results;
-        string[rules.length] names;
-        size_t[rules.length] failedLength;
+        ParseTree[] results = new ParseTree[rules.length];
+        string[] names = new string[rules.length];
+        size_t[] failedLength = new size_t[rules.length];
         size_t maxFailedLength;
 
         version (tracer)
@@ -1858,9 +1858,9 @@ template longest_match(rules...) if (rules.length > 0)
         size_t errorStringChars;
         string orErrorString;
 
-        ParseTree[rules.length] results;
-        string[rules.length] names;
-        size_t[rules.length] failedLength;
+        ParseTree[] results = new ParseTree[rules.length];
+        string[] names = new string[rules.length];
+        size_t[] failedLength = new size_t[rules.length];
         size_t maxFailedLength;
 
         version (tracer)


### PR DESCRIPTION
On big `or!()` templates stack size can grow pretty fast, specially when recursion is done on similar templates and recursive tail call optimizations are not possible.

For performance, LDC compiler already optimizes these calls into stack-based variables when they are too small. Regardless, this library heavily uses GC on the inner strings, so the impact is negligable.